### PR TITLE
修复mongo编码问题

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -17,8 +17,11 @@
         </RollingFile>
         <NoSql name="Mongo4">
             <MongoDb4 capped="true" collectionSize="104857600"
-                      connection="${sys:mongo.uri}.logs"
-            />
+                      connection="${sys:mongo.uri}.logs"/>
+            <codec>
+                <class>org.apache.logging.log4j.mongodb4.MongoDb4DocumentObject</class>
+                <includes>logger,message</includes>
+            </codec>
         </NoSql>
     </Appenders>
 

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -18,10 +18,6 @@
         <NoSql name="Mongo4">
             <MongoDb4 capped="true" collectionSize="104857600"
                       connection="${sys:mongo.uri}.logs"/>
-            <codec>
-                <class>org.apache.logging.log4j.mongodb4.MongoDb4DocumentObject</class>
-                <includes>logger,message</includes>
-            </codec>
         </NoSql>
     </Appenders>
 


### PR DESCRIPTION
问题：
当运行中，采用log4j2日志输入到mongo时候会出现编码问题。
```java

2023-04-19 08:33:31,447 replay-send-0 ERROR Unable to write to database [noSqlManager{ description=Mongo4, bufferSize=0, provider=MongoDb4Provider [connectionString=mongodb://arex:iLoveArex@mongodb:27017/arex_storage_db.logs, collectionSize=104857600, isCapped=true, mongoClient=com.mongodb.client.internal.MongoClientImpl@1b256636, mongoDatabase=com.mongodb.client.internal.MongoDatabaseImpl@7aab77f] }] for appender [Mongo4]. org.bson.codecs.configuration.CodecConfigurationException: Can't find a codec for class org.apache.logging.log4j.mongodb4.MongoDb4DocumentObject.
x-schedule  |    at com.arextest.schedule.sender.impl.HttpServletReplaySender.doInvoke(HttpServletReplaySender.java:169)
2023-04-19 16:33:31 arex-schedule  |    at com.arextest.schedule.sender.impl.HttpServletReplaySender.doSend(HttpServletReplaySender.java:101)
2023-04-19 16:33:31 arex-schedule  |    at com.arextest.schedule.sender.impl.HttpServletReplaySender.send(HttpServletReplaySender.java:129)
```
解决办法：
添加自定义编解码器