### PR TITLE
修复mongo编码问题

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-bom</artifactId>
-                <version>2.17.1</version>
+                <version>2.17.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
问题：
当运行中，采用log4j2日志输入到mongo时候会出现编码问题。

```java
2023-04-19 08:33:31,447 replay-send-0 ERROR Unable to write to database [noSqlManager{ description=Mongo4, bufferSize=0, provider=MongoDb4Provider [connectionString=mongodb://arex:iLoveArex@mongodb:27017/arex_storage_db.logs, collectionSize=104857600, isCapped=true, mongoClient=com.mongodb.client.internal.MongoClientImpl@1b256636, mongoDatabase=com.mongodb.client.internal.MongoDatabaseImpl@7aab77f] }] for appender [Mongo4]. org.bson.codecs.configuration.CodecConfigurationException: Can't find a codec for class org.apache.logging.log4j.mongodb4.MongoDb4DocumentObject.
x-schedule  |    at com.arextest.schedule.sender.impl.HttpServletReplaySender.doInvoke(HttpServletReplaySender.java:169)
2023-04-19 16:33:31 arex-schedule  |    at com.arextest.schedule.sender.impl.HttpServletReplaySender.doSend(HttpServletReplaySender.java:101)
2023-04-19 16:33:31 arex-schedule  |    at com.arextest.schedule.sender.impl.HttpServletReplaySender.send(HttpServletReplaySender.java:129)
```
解决办法：

升级版本  [1439](https://github.com/apache/logging-log4j2/issues/1439)