### PR TITLE
Feat plan execution context && QpsLimitter Optimization && parallel action item

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <spring.boot.version>2.6.3</spring.boot.version>
         <jmockit.version>1.37</jmockit.version>
         <lombok.version>1.18.2</lombok.version>
+        <guava.version>20.0</guava.version>
         <compare-sdk.version>0.1.13</compare-sdk.version>
         <jacoco-maven-plugin.version>0.7.5.201505241946</jacoco-maven-plugin.version>
 
@@ -44,6 +45,11 @@
     </properties>
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
+            </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
@@ -138,6 +144,10 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,10 +3,10 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <packaging>jar</packaging>
+    <packaging>${packagingType}</packaging>
     <groupId>com.arextest</groupId>
     <artifactId>arex-schedule-web-api</artifactId>
-    <version>1.0.24.1-SNAPSHOT</version>
+    <version>1.0.24</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>AREX schedule is used for replay.</description>
     <url>https://github.com/arextest/arex-replay-schedule</url>
@@ -341,20 +341,20 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
                     </plugin>
-                    <!--                    <plugin>-->
-                    <!--                        <groupId>org.apache.maven.plugins</groupId>-->
-                    <!--                        <artifactId>maven-gpg-plugin</artifactId>-->
-                    <!--                        <version>3.0.1</version>-->
-                    <!--                        <executions>-->
-                    <!--                            <execution>-->
-                    <!--                                <id>sign-artifacts</id>-->
-                    <!--                                <phase>verify</phase>-->
-                    <!--                                <goals>-->
-                    <!--                                    <goal>sign</goal>-->
-                    <!--                                </goals>-->
-                    <!--                            </execution>-->
-                    <!--                        </executions>-->
-                    <!--                    </plugin>-->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.0.1</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
@@ -428,8 +428,8 @@
             <id>jar-local</id>
             <properties>
                 <packagingType>jar</packagingType>
-                <releases.repo>http://maven.release.ctripcorp.com/nexus/content/repositories/flightsnapshot</releases.repo>
-                <snapshots.repo>http://maven.release.ctripcorp.com/nexus/content/repositories/flightsnapshot</snapshots.repo>
+                <releases.repo></releases.repo>
+                <snapshots.repo></snapshots.repo>
             </properties>
             <build>
                 <resources>

--- a/pom.xml
+++ b/pom.xml
@@ -3,10 +3,10 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <packaging>${packagingType}</packaging>
+    <packaging>jar</packaging>
     <groupId>com.arextest</groupId>
     <artifactId>arex-schedule-web-api</artifactId>
-    <version>1.0.24</version>
+    <version>1.0.24.1-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>AREX schedule is used for replay.</description>
     <url>https://github.com/arextest/arex-replay-schedule</url>
@@ -341,20 +341,20 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
                     </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.0.1</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
+                    <!--                    <plugin>-->
+                    <!--                        <groupId>org.apache.maven.plugins</groupId>-->
+                    <!--                        <artifactId>maven-gpg-plugin</artifactId>-->
+                    <!--                        <version>3.0.1</version>-->
+                    <!--                        <executions>-->
+                    <!--                            <execution>-->
+                    <!--                                <id>sign-artifacts</id>-->
+                    <!--                                <phase>verify</phase>-->
+                    <!--                                <goals>-->
+                    <!--                                    <goal>sign</goal>-->
+                    <!--                                </goals>-->
+                    <!--                            </execution>-->
+                    <!--                        </executions>-->
+                    <!--                    </plugin>-->
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
@@ -428,8 +428,8 @@
             <id>jar-local</id>
             <properties>
                 <packagingType>jar</packagingType>
-                <releases.repo></releases.repo>
-                <snapshots.repo></snapshots.repo>
+                <releases.repo>http://maven.release.ctripcorp.com/nexus/content/repositories/flightsnapshot</releases.repo>
+                <snapshots.repo>http://maven.release.ctripcorp.com/nexus/content/repositories/flightsnapshot</snapshots.repo>
             </properties>
             <build>
                 <resources>

--- a/src/main/java/com/arextest/schedule/beans/ExecutionContextConfiguration.java
+++ b/src/main/java/com/arextest/schedule/beans/ExecutionContextConfiguration.java
@@ -1,6 +1,7 @@
 package com.arextest.schedule.beans;
 
 import com.arextest.schedule.planexecution.DefaultExecutionContextProvider;
+import com.arextest.schedule.planexecution.PlanExecutionContextProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -12,9 +13,8 @@ import org.springframework.context.annotation.Configuration;
 public class ExecutionContextConfiguration {
     @Bean
     @ConditionalOnMissingBean
-    public DefaultExecutionContextProvider defaultExecutionContextBuilder() {
+    @SuppressWarnings("rawtypes")
+    public PlanExecutionContextProvider defaultExecutionContextBuilder() {
         return new DefaultExecutionContextProvider();
     }
-
-
 }

--- a/src/main/java/com/arextest/schedule/beans/ExecutionContextConfiguration.java
+++ b/src/main/java/com/arextest/schedule/beans/ExecutionContextConfiguration.java
@@ -1,0 +1,20 @@
+package com.arextest.schedule.beans;
+
+import com.arextest.schedule.planexecution.DefaultExecutionContextProvider;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Slf4j
+@Configuration
+public class ExecutionContextConfiguration {
+    @Bean
+    @ConditionalOnMissingBean
+    public DefaultExecutionContextProvider defaultExecutionContextBuilder() {
+        return new DefaultExecutionContextProvider();
+    }
+
+
+}

--- a/src/main/java/com/arextest/schedule/beans/ExecutorServiceConfiguration.java
+++ b/src/main/java/com/arextest/schedule/beans/ExecutorServiceConfiguration.java
@@ -20,7 +20,6 @@ class ExecutorServiceConfiguration implements Thread.UncaughtExceptionHandler {
     private static final int MAXIMUM_POOL_SIZE = 2 * CORE_POOL_SIZE;
     private static final int SEND_QUEUE_MAX_CAPACITY_SIZE = 2000;
     private static final int PRELOAD_QUEUE_MAX_CAPACITY_SIZE = 100;
-    private static final int ACTION_ITEM_QUEUE_MAX_CAPACITY_SIZE = 200;
     private final int SEND_POOL_SIZE = calculateIOPoolSize();
 
     @Value("${arex.schedule.pool.io.cpuratio}")
@@ -58,7 +57,7 @@ class ExecutorServiceConfiguration implements Thread.UncaughtExceptionHandler {
                 .build();
         return new ThreadPoolExecutor(CORE_POOL_SIZE, MAXIMUM_POOL_SIZE,
                 KEEP_ALIVE_TIME, TimeUnit.MILLISECONDS,
-                new LinkedBlockingQueue<>(ACTION_ITEM_QUEUE_MAX_CAPACITY_SIZE),
+                new LinkedBlockingQueue<>(MAXIMUM_POOL_SIZE * 2),
                 threadFactory,
                 new ThreadPoolExecutor.CallerRunsPolicy());
     }

--- a/src/main/java/com/arextest/schedule/beans/ExecutorServiceConfiguration.java
+++ b/src/main/java/com/arextest/schedule/beans/ExecutorServiceConfiguration.java
@@ -24,7 +24,7 @@ class ExecutorServiceConfiguration implements Thread.UncaughtExceptionHandler {
     private static final int SEND_QUEUE_MAX_CAPACITY_SIZE = 2000;
     private static final int PRELOAD_QUEUE_MAX_CAPACITY_SIZE = 100;
 
-    private static final int SEND_POOL_SIZE = ExecutorServiceConfiguration.calculateIOPoolThreadPoolSize();
+    private static final int SEND_POOL_SIZE = ExecutorServiceConfiguration.calculateIOPoolSize();
 
     @Bean
     public ExecutorService preloadExecutorService() {
@@ -55,7 +55,7 @@ class ExecutorServiceConfiguration implements Thread.UncaughtExceptionHandler {
         LOGGER.error("uncaughtException {} ,error :{}", t.getName(), e.getMessage(), e);
     }
 
-    private static int calculateIOPoolThreadPoolSize() {
+    private static int calculateIOPoolSize() {
         int nThreads = Runtime.getRuntime().availableProcessors();
         double targetCPUUtilization = 0.8;
         double wC = 3.0; // assume wait time is 5 times compute time

--- a/src/main/java/com/arextest/schedule/beans/ExecutorServiceConfiguration.java
+++ b/src/main/java/com/arextest/schedule/beans/ExecutorServiceConfiguration.java
@@ -19,6 +19,7 @@ class ExecutorServiceConfiguration implements Thread.UncaughtExceptionHandler {
     private static final int MAXIMUM_POOL_SIZE = 2 * CORE_POOL_SIZE;
     private static final int SEND_QUEUE_MAX_CAPACITY_SIZE = 2000;
     private static final int PRELOAD_QUEUE_MAX_CAPACITY_SIZE = 100;
+    private static final int ACTION_ITEM_QUEUE_MAX_CAPACITY_SIZE = 200;
 
     private static final int SEND_POOL_SIZE = ExecutorServiceConfiguration.calculateIOPoolSize();
 
@@ -52,9 +53,11 @@ class ExecutorServiceConfiguration implements Thread.UncaughtExceptionHandler {
                 .setDaemon(true)
                 .setUncaughtExceptionHandler(this)
                 .build();
-        return new ThreadPoolExecutor(CORE_POOL_SIZE,
-                MAXIMUM_POOL_SIZE, KEEP_ALIVE_TIME,
-                TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(PRELOAD_QUEUE_MAX_CAPACITY_SIZE), threadFactory);
+        return new ThreadPoolExecutor(CORE_POOL_SIZE, MAXIMUM_POOL_SIZE,
+                KEEP_ALIVE_TIME, TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<>(ACTION_ITEM_QUEUE_MAX_CAPACITY_SIZE),
+                threadFactory,
+                new ThreadPoolExecutor.CallerRunsPolicy());
     }
 
     @Override

--- a/src/main/java/com/arextest/schedule/beans/ExecutorServiceConfiguration.java
+++ b/src/main/java/com/arextest/schedule/beans/ExecutorServiceConfiguration.java
@@ -5,11 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 /**
  * @author jmo
@@ -48,6 +44,17 @@ class ExecutorServiceConfiguration implements Thread.UncaughtExceptionHandler {
                 .build();
         return new ThreadPoolExecutor(SEND_POOL_SIZE, SEND_POOL_SIZE, KEEP_ALIVE_TIME,
                 TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(SEND_QUEUE_MAX_CAPACITY_SIZE), threadFactory);
+    }
+
+    @Bean
+    public ExecutorService actionItemParallelPool() {
+        ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("replay-action-parallel-%d")
+                .setDaemon(true)
+                .setUncaughtExceptionHandler(this)
+                .build();
+        return new ThreadPoolExecutor(CORE_POOL_SIZE,
+                MAXIMUM_POOL_SIZE, KEEP_ALIVE_TIME,
+                TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(PRELOAD_QUEUE_MAX_CAPACITY_SIZE), threadFactory);
     }
 
     @Override

--- a/src/main/java/com/arextest/schedule/beans/ExecutorServiceConfiguration.java
+++ b/src/main/java/com/arextest/schedule/beans/ExecutorServiceConfiguration.java
@@ -24,6 +24,8 @@ class ExecutorServiceConfiguration implements Thread.UncaughtExceptionHandler {
     private static final int SEND_QUEUE_MAX_CAPACITY_SIZE = 2000;
     private static final int PRELOAD_QUEUE_MAX_CAPACITY_SIZE = 100;
 
+    private static final int SEND_POOL_SIZE = ExecutorServiceConfiguration.calculateIOPoolThreadPoolSize();
+
     @Bean
     public ExecutorService preloadExecutorService() {
         ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("replay-preload-%d")
@@ -35,19 +37,29 @@ class ExecutorServiceConfiguration implements Thread.UncaughtExceptionHandler {
                 TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(PRELOAD_QUEUE_MAX_CAPACITY_SIZE), threadFactory);
     }
 
+    /**
+     * This bean should be overridden according to the actual implementation of compare service
+     */
     @Bean
     public ExecutorService sendExecutorService() {
         ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("replay-send-%d")
                 .setDaemon(true)
                 .setUncaughtExceptionHandler(this)
                 .build();
-        return new ThreadPoolExecutor(MAXIMUM_POOL_SIZE,
-                MAXIMUM_POOL_SIZE, KEEP_ALIVE_TIME,
+        return new ThreadPoolExecutor(SEND_POOL_SIZE, SEND_POOL_SIZE, KEEP_ALIVE_TIME,
                 TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(SEND_QUEUE_MAX_CAPACITY_SIZE), threadFactory);
     }
 
     @Override
     public void uncaughtException(Thread t, Throwable e) {
         LOGGER.error("uncaughtException {} ,error :{}", t.getName(), e.getMessage(), e);
+    }
+
+    private static int calculateIOPoolThreadPoolSize() {
+        int nThreads = Runtime.getRuntime().availableProcessors();
+        double targetCPUUtilization = 0.8;
+        double wC = 3.0; // assume wait time is 5 times compute time
+        int optimalThreadPoolSize = (int) Math.ceil(nThreads * targetCPUUtilization * (1 + wC));
+        return optimalThreadPoolSize;
     }
 }

--- a/src/main/java/com/arextest/schedule/dao/mongodb/ReplayActionCaseItemRepository.java
+++ b/src/main/java/com/arextest/schedule/dao/mongodb/ReplayActionCaseItemRepository.java
@@ -46,8 +46,12 @@ public class ReplayActionCaseItemRepository implements RepositoryWriter<ReplayAc
         return insert.getId() != null;
     }
 
-    public List<ReplayActionCaseItem> waitingSendList(String planItemId, int pageSize, Query baseQuery) {
-        Query query = Optional.ofNullable(baseQuery).orElse(new Query());
+    public List<ReplayActionCaseItem> waitingSendList(String planItemId, int pageSize, List<Criteria> baseCriteria) {
+        Query query = new Query();
+
+        Optional.ofNullable(baseCriteria).ifPresent(criteria -> {
+            criteria.forEach(query::addCriteria);
+        });
 
         query.addCriteria(Criteria.where(PLAN_ITEM_ID).is(planItemId));
         query.addCriteria(Criteria.where(SEND_STATUS).is(CaseSendStatusType.WAIT_HANDLING.getValue()));

--- a/src/main/java/com/arextest/schedule/dao/mongodb/ReplayActionCaseItemRepository.java
+++ b/src/main/java/com/arextest/schedule/dao/mongodb/ReplayActionCaseItemRepository.java
@@ -8,7 +8,6 @@ import com.arextest.schedule.model.ReplayActionCaseItem;
 import com.arextest.schedule.model.converter.ReplayRunDetailsConverter;
 import com.arextest.schedule.model.dao.mongodb.ReplayRunDetailsCollection;
 import com.mongodb.client.result.UpdateResult;
-import jdk.internal.jline.internal.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -17,7 +16,6 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Repository;
 
-import javax.validation.constraints.Null;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -48,7 +46,7 @@ public class ReplayActionCaseItemRepository implements RepositoryWriter<ReplayAc
         return insert.getId() != null;
     }
 
-    public List<ReplayActionCaseItem> waitingSendList(String planItemId, int pageSize, @Nullable Query baseQuery) {
+    public List<ReplayActionCaseItem> waitingSendList(String planItemId, int pageSize, Query baseQuery) {
         Query query = Optional.ofNullable(baseQuery).orElse(new Query());
 
         query.addCriteria(Criteria.where(PLAN_ITEM_ID).is(planItemId));

--- a/src/main/java/com/arextest/schedule/dao/mongodb/ReplayActionCaseItemRepository.java
+++ b/src/main/java/com/arextest/schedule/dao/mongodb/ReplayActionCaseItemRepository.java
@@ -64,6 +64,22 @@ public class ReplayActionCaseItemRepository implements RepositoryWriter<ReplayAc
         return replayRunDetailsCollections.stream().map(ReplayRunDetailsConverter.INSTANCE::dtoFromDao).collect(Collectors.toList());
     }
 
+    public long countWaitingSendList(String planItemId, List<Criteria> baseCriteria) {
+        Query query = new Query();
+
+        Optional.ofNullable(baseCriteria).ifPresent(criteria -> {
+            criteria.forEach(query::addCriteria);
+        });
+
+        query.addCriteria(Criteria.where(PLAN_ITEM_ID).is(planItemId));
+        query.addCriteria(Criteria.where(SEND_STATUS).is(CaseSendStatusType.WAIT_HANDLING.getValue()));
+        query.with(Sort.by(
+                Sort.Order.asc(DASH_ID),
+                Sort.Order.asc(REPLAY_DEPENDENCE)
+        ));
+        return mongoTemplate.count(query, ReplayRunDetailsCollection.class);
+    }
+
     public boolean updateSendResult(ReplayActionCaseItem replayActionCaseItem) {
         Query query = Query.query(Criteria.where(DASH_ID).is(replayActionCaseItem.getId()));
         Update update = MongoHelper.getUpdate();

--- a/src/main/java/com/arextest/schedule/dao/mongodb/ReplayActionCaseItemRepository.java
+++ b/src/main/java/com/arextest/schedule/dao/mongodb/ReplayActionCaseItemRepository.java
@@ -8,6 +8,7 @@ import com.arextest.schedule.model.ReplayActionCaseItem;
 import com.arextest.schedule.model.converter.ReplayRunDetailsConverter;
 import com.arextest.schedule.model.dao.mongodb.ReplayRunDetailsCollection;
 import com.mongodb.client.result.UpdateResult;
+import jdk.internal.jline.internal.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -16,7 +17,9 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Repository;
 
+import javax.validation.constraints.Null;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -45,8 +48,10 @@ public class ReplayActionCaseItemRepository implements RepositoryWriter<ReplayAc
         return insert.getId() != null;
     }
 
-    public List<ReplayActionCaseItem> waitingSendList(String planItemId, int pageSize) {
-        Query query = Query.query(Criteria.where(PLAN_ITEM_ID).is(planItemId));
+    public List<ReplayActionCaseItem> waitingSendList(String planItemId, int pageSize, @Nullable Query baseQuery) {
+        Query query = Optional.ofNullable(baseQuery).orElse(new Query());
+
+        query.addCriteria(Criteria.where(PLAN_ITEM_ID).is(planItemId));
         query.addCriteria(Criteria.where(SEND_STATUS).is(CaseSendStatusType.WAIT_HANDLING.getValue()));
         query.limit(pageSize);
         query.with(Sort.by(

--- a/src/main/java/com/arextest/schedule/mdc/MDCTracer.java
+++ b/src/main/java/com/arextest/schedule/mdc/MDCTracer.java
@@ -12,8 +12,8 @@ public final class MDCTracer {
     private static final String PLAN_ID = "planId";
     private static final String ACTION_ID = "actionId";
     private static final String DETAIL_ID = "detailId";
-
     private static final String PLAN_ITEM_ID = "planItemId";
+    private static final String EXECUTION_CONTEXT_NAME = "executionContextName";
 
     private static final String APP_TYPE = "app-type";
     private static final String AREX_SCHEDULE = "arex-schedule";
@@ -40,6 +40,11 @@ public final class MDCTracer {
     public static void addPlanId(String planId) {
         addAppType();
         MDC.put(PLAN_ID, planId);
+    }
+
+    public static void addExecutionContextNme(String contextName) {
+        addAppType();
+        MDC.put(EXECUTION_CONTEXT_NAME, contextName);
     }
 
     public static void addPlanItemId(String planItemId) {

--- a/src/main/java/com/arextest/schedule/model/ExecutionContextActionType.java
+++ b/src/main/java/com/arextest/schedule/model/ExecutionContextActionType.java
@@ -2,5 +2,5 @@ package com.arextest.schedule.model;
 
 public enum ExecutionContextActionType {
     NORMAL,
-    INTERRUPT_CASES_OF_CONTEXT;
+    SKIP_CASE_OF_CONTEXT;
 }

--- a/src/main/java/com/arextest/schedule/model/ExecutionContextActionType.java
+++ b/src/main/java/com/arextest/schedule/model/ExecutionContextActionType.java
@@ -1,0 +1,6 @@
+package com.arextest.schedule.model;
+
+public enum ExecutionContextActionType {
+    NORMAL,
+    INTERRUPT_CASES_OF_CONTEXT;
+}

--- a/src/main/java/com/arextest/schedule/model/ExecutionStatus.java
+++ b/src/main/java/com/arextest/schedule/model/ExecutionStatus.java
@@ -3,20 +3,40 @@ package com.arextest.schedule.model;
 import lombok.Builder;
 import lombok.Data;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 /**
  * Created by Qzmo on 2023/5/15
  */
-@Data
 @Builder
 public class ExecutionStatus {
-    private boolean canceled;
-    private boolean interrupted;
+    private AtomicReference<Boolean> canceled;
+    private AtomicReference<Boolean> interrupted;
 
     public boolean isNormal() {
-        return !canceled && !interrupted;
+        return !canceled.get() && !interrupted.get();
+    }
+
+    public boolean isInterrupted() {
+        return this.interrupted.get();
+    }
+
+    public void setInterrupted(boolean newVal) {
+        this.interrupted.getAndUpdate((old) -> old || newVal);
+    }
+
+    public boolean isCanceled() {
+        return this.canceled.get();
+    }
+
+    public void setCanceled(boolean newVal) {
+        this.canceled.getAndUpdate((old) -> old || newVal);
     }
 
     public static ExecutionStatus buildNormal() {
-        return ExecutionStatus.builder().build();
+        return ExecutionStatus.builder()
+                .canceled(new AtomicReference<>(false))
+                .interrupted(new AtomicReference<>(false))
+                .build();
     }
 }

--- a/src/main/java/com/arextest/schedule/model/ExecutionStatus.java
+++ b/src/main/java/com/arextest/schedule/model/ExecutionStatus.java
@@ -1,0 +1,22 @@
+package com.arextest.schedule.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Created by Qzmo on 2023/5/15
+ */
+@Data
+@Builder
+public class ExecutionStatus {
+    private boolean canceled;
+    private boolean interrupted;
+
+    public boolean isNormal() {
+        return !canceled && !interrupted;
+    }
+
+    public static ExecutionStatus buildNormal() {
+        return ExecutionStatus.builder().build();
+    }
+}

--- a/src/main/java/com/arextest/schedule/model/PlanExecutionContext.java
+++ b/src/main/java/com/arextest/schedule/model/PlanExecutionContext.java
@@ -2,9 +2,9 @@ package com.arextest.schedule.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
-import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Criteria;
 
-import java.util.Map;
+import java.util.List;
 
 /**
  * Created by Qzmo on 2023/5/15
@@ -15,7 +15,7 @@ public class PlanExecutionContext<T> {
 
     // extra condition provide for case selecting before send
     @JsonIgnore
-    private Query contextCaceQuery;
+    private List<Criteria> contextCaseQuery;
 
     @JsonIgnore
     private T dependencies;

--- a/src/main/java/com/arextest/schedule/model/PlanExecutionContext.java
+++ b/src/main/java/com/arextest/schedule/model/PlanExecutionContext.java
@@ -13,6 +13,9 @@ import java.util.List;
 public class PlanExecutionContext<T> {
     private String contextName;
 
+    @JsonIgnore
+    private ExecutionStatus executionStatus;
+
     // extra condition provide for case selecting before send
     @JsonIgnore
     private List<Criteria> contextCaseQuery;

--- a/src/main/java/com/arextest/schedule/model/PlanExecutionContext.java
+++ b/src/main/java/com/arextest/schedule/model/PlanExecutionContext.java
@@ -1,0 +1,19 @@
+package com.arextest.schedule.model;
+
+import jdk.internal.jline.internal.Nullable;
+import lombok.Data;
+import org.springframework.data.mongodb.core.query.Query;
+
+import java.util.Map;
+
+/**
+ * Created by Qzmo on 2023/5/15
+ */
+@Data
+public class PlanExecutionContext {
+    // extra condition provide for case selecting before send
+    @Nullable
+    private Query contextCaceQuery;
+
+    private Map<String, String> dependencies;
+}

--- a/src/main/java/com/arextest/schedule/model/PlanExecutionContext.java
+++ b/src/main/java/com/arextest/schedule/model/PlanExecutionContext.java
@@ -12,6 +12,7 @@ import java.util.List;
 @Data
 public class PlanExecutionContext<T> {
     private String contextName;
+    private ExecutionContextActionType actionType = ExecutionContextActionType.NORMAL;
 
     @JsonIgnore
     private ExecutionStatus executionStatus;

--- a/src/main/java/com/arextest/schedule/model/PlanExecutionContext.java
+++ b/src/main/java/com/arextest/schedule/model/PlanExecutionContext.java
@@ -1,6 +1,5 @@
 package com.arextest.schedule.model;
 
-import jdk.internal.jline.internal.Nullable;
 import lombok.Data;
 import org.springframework.data.mongodb.core.query.Query;
 
@@ -12,7 +11,6 @@ import java.util.Map;
 @Data
 public class PlanExecutionContext {
     // extra condition provide for case selecting before send
-    @Nullable
     private Query contextCaceQuery;
 
     private Map<String, String> dependencies;

--- a/src/main/java/com/arextest/schedule/model/PlanExecutionContext.java
+++ b/src/main/java/com/arextest/schedule/model/PlanExecutionContext.java
@@ -1,5 +1,6 @@
 package com.arextest.schedule.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 import org.springframework.data.mongodb.core.query.Query;
 
@@ -9,9 +10,13 @@ import java.util.Map;
  * Created by Qzmo on 2023/5/15
  */
 @Data
-public class PlanExecutionContext {
+public class PlanExecutionContext<T> {
+    private String contextName;
+
     // extra condition provide for case selecting before send
+    @JsonIgnore
     private Query contextCaceQuery;
 
-    private Map<String, String> dependencies;
+    @JsonIgnore
+    private T dependencies;
 }

--- a/src/main/java/com/arextest/schedule/model/ReplayActionCaseItem.java
+++ b/src/main/java/com/arextest/schedule/model/ReplayActionCaseItem.java
@@ -23,6 +23,7 @@ public class ReplayActionCaseItem {
     private String recordId;
     private String targetResultId;
     private String sourceResultId;
+    private String contextIdentifier;
 
     private ReplayActionItem parent;
     /**

--- a/src/main/java/com/arextest/schedule/model/ReplayActionItem.java
+++ b/src/main/java/com/arextest/schedule/model/ReplayActionItem.java
@@ -97,5 +97,7 @@ public class ReplayActionItem {
     @JsonIgnore
     private String errorMessage;
     @JsonIgnore
-    private boolean processed;
+    private boolean itemProcessed;
+    @JsonIgnore
+    private int caseProcessCount;
 }

--- a/src/main/java/com/arextest/schedule/model/ReplayActionItem.java
+++ b/src/main/java/com/arextest/schedule/model/ReplayActionItem.java
@@ -96,4 +96,6 @@ public class ReplayActionItem {
 
     @JsonIgnore
     private String errorMessage;
+    @JsonIgnore
+    private boolean processed;
 }

--- a/src/main/java/com/arextest/schedule/model/ReplayActionItem.java
+++ b/src/main/java/com/arextest/schedule/model/ReplayActionItem.java
@@ -100,4 +100,8 @@ public class ReplayActionItem {
     private boolean itemProcessed;
     @JsonIgnore
     private int caseProcessCount;
+
+    public void recordProcessCaseCount(int incoming) {
+        setCaseProcessCount(caseProcessCount + incoming);
+    }
 }

--- a/src/main/java/com/arextest/schedule/model/ReplayPlan.java
+++ b/src/main/java/com/arextest/schedule/model/ReplayPlan.java
@@ -6,10 +6,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 import lombok.ToString;
 
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * @author jmo
@@ -73,7 +70,9 @@ public class ReplayPlan {
     private int caseCountLimit;
     @JsonIgnore
     private String errorMessage;
-
     private transient long planCreateMillis;
 
+    // Min(targetInstanceCount || Int.MAX, sourceInstanceCount || Int.MAX)
+    @JsonIgnore
+    private int minInstanceCount;
 }

--- a/src/main/java/com/arextest/schedule/model/ReplayPlan.java
+++ b/src/main/java/com/arextest/schedule/model/ReplayPlan.java
@@ -7,7 +7,9 @@ import lombok.Data;
 import lombok.ToString;
 
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author jmo
@@ -64,10 +66,11 @@ public class ReplayPlan {
     @JsonIgnore
     private List<ReplayActionItem> replayActionItemList;
     @JsonIgnore
+    private List<PlanExecutionContext> executionContexts;
+    @JsonIgnore
     private String appName;
     @JsonIgnore
     private int caseCountLimit;
-
     @JsonIgnore
     private String errorMessage;
 

--- a/src/main/java/com/arextest/schedule/model/dao/mongodb/ReplayRunDetailsCollection.java
+++ b/src/main/java/com/arextest/schedule/model/dao/mongodb/ReplayRunDetailsCollection.java
@@ -22,6 +22,7 @@ public class ReplayRunDetailsCollection extends ModelBase {
     private String targetResultId;
     @NonNull
     private String sourceResultId;
+    private String contextIdentifier;
     private int sendStatus;
     private int compareStatus;
     private String caseType;

--- a/src/main/java/com/arextest/schedule/model/plan/BuildReplayPlanType.java
+++ b/src/main/java/com/arextest/schedule/model/plan/BuildReplayPlanType.java
@@ -2,6 +2,9 @@ package com.arextest.schedule.model.plan;
 
 import lombok.Getter;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * @author jmo
  * @since 2021/9/18
@@ -30,5 +33,16 @@ public enum BuildReplayPlanType {
 
     BuildReplayPlanType(int value) {
         this.value = value;
+    }
+
+    private static final Map<Integer, BuildReplayPlanType> BY_VALUE_MAP = new HashMap<>();
+    static {
+        for (BuildReplayPlanType type : values()) {
+            BY_VALUE_MAP.put(type.getValue(), type);
+        }
+    }
+
+    public static BuildReplayPlanType findByValue(int value) {
+        return BY_VALUE_MAP.get(value);
     }
 }

--- a/src/main/java/com/arextest/schedule/plan/PlanContext.java
+++ b/src/main/java/com/arextest/schedule/plan/PlanContext.java
@@ -146,4 +146,14 @@ public final class PlanContext {
         }
         return null;
     }
+
+    // if both target env and source env are given, return the min(target, source) to throttle qps
+    public int determineMinInstanceCount() {
+        int min = targetActiveInstance().size();
+        List<ServiceInstance> sourceInstance = sourceActiveInstance();
+        if (CollectionUtils.isNotEmpty(sourceInstance)) {
+            min = Math.min(min, sourceInstance.size());
+        }
+        return min;
+    }
 }

--- a/src/main/java/com/arextest/schedule/planexecution/DefaultExecutionContextProvider.java
+++ b/src/main/java/com/arextest/schedule/planexecution/DefaultExecutionContextProvider.java
@@ -1,28 +1,58 @@
 package com.arextest.schedule.planexecution;
 
+import com.arextest.schedule.mdc.MDCTracer;
 import com.arextest.schedule.model.PlanExecutionContext;
 import com.arextest.schedule.model.ReplayPlan;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.query.BasicQuery;
+import org.springframework.data.mongodb.core.query.Query;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Created by Qzmo on 2023/5/15
+ *
+ * Default implementation illustrating functionalities of execution context
  */
-public class DefaultExecutionContextProvider implements PlanExecutionContextProvider {
+@Slf4j
+public class DefaultExecutionContextProvider implements PlanExecutionContextProvider<Map<String, String>> {
+
+    private final static String REMOTE_CONFIG_DEP_KEY = "CONFIG_VER";
+    private final static String DEFAULT_CONTEXT_NAME = "DEFAULT_EXECUTION_CONTEXT";
 
     @Override
-    public List<PlanExecutionContext> buildContext(ReplayPlan plan) {
-        return Collections.singletonList(new PlanExecutionContext());
+    public List<PlanExecutionContext<Map<String, String>>> buildContext(ReplayPlan plan) {
+        PlanExecutionContext<Map<String, String>> singletonContext = new PlanExecutionContext<>();
+        singletonContext.setContextName(DEFAULT_CONTEXT_NAME);
+
+        // store dependency version for further usage
+        HashMap<String, String> dependencies = new HashMap<>();
+        dependencies.put(REMOTE_CONFIG_DEP_KEY, "EXAMPLE_VER");
+        singletonContext.setDependencies(dependencies);
+
+        // set up base query for cases belonging to this context
+        Query baseQuery = new Query();
+        singletonContext.setContextCaceQuery(baseQuery);
+
+        List<PlanExecutionContext<Map<String, String>>> contexts = Collections.singletonList(singletonContext);
+        LOGGER.info("Constructed contexts of size: {}", contexts.size());
+
+        return contexts;
     }
 
     @Override
-    public void onBeforeContextExecution(PlanExecutionContext currentContext, ReplayPlan plan) {
-
+    public void onBeforeContextExecution(PlanExecutionContext<Map<String, String>> currentContext, ReplayPlan plan) {
+        MDCTracer.addExecutionContextNme(currentContext.getContextName());
+        LOGGER.info("Start executing context: {}", currentContext);
+        // prepare dependencies before sending any cases of this context...
     }
 
     @Override
-    public void onAfterContextExecution(PlanExecutionContext currentContext, ReplayPlan plan) {
-
+    public void onAfterContextExecution(PlanExecutionContext<Map<String, String>> currentContext, ReplayPlan plan) {
+        LOGGER.info("Finished executing context: {}", currentContext);
+        // clean up context related resources on target instances...
     }
 }

--- a/src/main/java/com/arextest/schedule/planexecution/DefaultExecutionContextProvider.java
+++ b/src/main/java/com/arextest/schedule/planexecution/DefaultExecutionContextProvider.java
@@ -1,0 +1,28 @@
+package com.arextest.schedule.planexecution;
+
+import com.arextest.schedule.model.PlanExecutionContext;
+import com.arextest.schedule.model.ReplayPlan;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Created by Qzmo on 2023/5/15
+ */
+public class DefaultExecutionContextProvider implements PlanExecutionContextProvider {
+
+    @Override
+    public List<PlanExecutionContext> buildContext(ReplayPlan plan) {
+        return Collections.singletonList(new PlanExecutionContext());
+    }
+
+    @Override
+    public void onBeforeContextExecution(PlanExecutionContext currentContext, ReplayPlan plan) {
+
+    }
+
+    @Override
+    public void onAfterContextExecution(PlanExecutionContext currentContext, ReplayPlan plan) {
+
+    }
+}

--- a/src/main/java/com/arextest/schedule/planexecution/DefaultExecutionContextProvider.java
+++ b/src/main/java/com/arextest/schedule/planexecution/DefaultExecutionContextProvider.java
@@ -2,8 +2,10 @@ package com.arextest.schedule.planexecution;
 
 import com.arextest.schedule.mdc.MDCTracer;
 import com.arextest.schedule.model.PlanExecutionContext;
+import com.arextest.schedule.model.ReplayActionCaseItem;
 import com.arextest.schedule.model.ReplayPlan;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 
@@ -38,6 +40,13 @@ public class DefaultExecutionContextProvider implements PlanExecutionContextProv
         LOGGER.info("Constructed contexts of size: {}", contexts.size());
 
         return contexts;
+    }
+
+    @Override
+    public void injectContextIntoCase(List<ReplayActionCaseItem> cases) {
+        cases.forEach(caseItem -> {
+            caseItem.setContextIdentifier(StringUtils.EMPTY);
+        });
     }
 
     @Override

--- a/src/main/java/com/arextest/schedule/planexecution/DefaultExecutionContextProvider.java
+++ b/src/main/java/com/arextest/schedule/planexecution/DefaultExecutionContextProvider.java
@@ -4,13 +4,10 @@ import com.arextest.schedule.mdc.MDCTracer;
 import com.arextest.schedule.model.PlanExecutionContext;
 import com.arextest.schedule.model.ReplayPlan;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.mongodb.core.query.BasicQuery;
+import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Created by Qzmo on 2023/5/15
@@ -34,8 +31,8 @@ public class DefaultExecutionContextProvider implements PlanExecutionContextProv
         singletonContext.setDependencies(dependencies);
 
         // set up base query for cases belonging to this context
-        Query baseQuery = new Query();
-        singletonContext.setContextCaceQuery(baseQuery);
+        Criteria dummyCriteria = Criteria.where("dataChangeCreateTime").gt(0);
+        singletonContext.setContextCaseQuery(Collections.singletonList(dummyCriteria));
 
         List<PlanExecutionContext<Map<String, String>>> contexts = Collections.singletonList(singletonContext);
         LOGGER.info("Constructed contexts of size: {}", contexts.size());

--- a/src/main/java/com/arextest/schedule/planexecution/PlanExecutionContextProvider.java
+++ b/src/main/java/com/arextest/schedule/planexecution/PlanExecutionContextProvider.java
@@ -1,6 +1,7 @@
 package com.arextest.schedule.planexecution;
 
 import com.arextest.schedule.model.PlanExecutionContext;
+import com.arextest.schedule.model.ReplayActionCaseItem;
 import com.arextest.schedule.model.ReplayPlan;
 
 import java.util.List;
@@ -10,6 +11,7 @@ import java.util.List;
  */
 public interface PlanExecutionContextProvider<T> {
     List<PlanExecutionContext<T>> buildContext(ReplayPlan plan);
+    void injectContextIntoCase(List<ReplayActionCaseItem> cases);
     void onBeforeContextExecution(PlanExecutionContext<T> currentContext, ReplayPlan plan);
     void onAfterContextExecution(PlanExecutionContext<T> currentContext, ReplayPlan plan);
 }

--- a/src/main/java/com/arextest/schedule/planexecution/PlanExecutionContextProvider.java
+++ b/src/main/java/com/arextest/schedule/planexecution/PlanExecutionContextProvider.java
@@ -10,7 +10,6 @@ import java.util.List;
  */
 public interface PlanExecutionContextProvider {
     List<PlanExecutionContext> buildContext(ReplayPlan plan);
-
     void onBeforeContextExecution(PlanExecutionContext currentContext, ReplayPlan plan);
     void onAfterContextExecution(PlanExecutionContext currentContext, ReplayPlan plan);
 }

--- a/src/main/java/com/arextest/schedule/planexecution/PlanExecutionContextProvider.java
+++ b/src/main/java/com/arextest/schedule/planexecution/PlanExecutionContextProvider.java
@@ -8,8 +8,8 @@ import java.util.List;
 /**
  * Created by Qzmo on 2023/5/15
  */
-public interface PlanExecutionContextProvider {
-    List<PlanExecutionContext> buildContext(ReplayPlan plan);
-    void onBeforeContextExecution(PlanExecutionContext currentContext, ReplayPlan plan);
-    void onAfterContextExecution(PlanExecutionContext currentContext, ReplayPlan plan);
+public interface PlanExecutionContextProvider<T> {
+    List<PlanExecutionContext<T>> buildContext(ReplayPlan plan);
+    void onBeforeContextExecution(PlanExecutionContext<T> currentContext, ReplayPlan plan);
+    void onAfterContextExecution(PlanExecutionContext<T> currentContext, ReplayPlan plan);
 }

--- a/src/main/java/com/arextest/schedule/planexecution/PlanExecutionContextProvider.java
+++ b/src/main/java/com/arextest/schedule/planexecution/PlanExecutionContextProvider.java
@@ -1,0 +1,16 @@
+package com.arextest.schedule.planexecution;
+
+import com.arextest.schedule.model.PlanExecutionContext;
+import com.arextest.schedule.model.ReplayPlan;
+
+import java.util.List;
+
+/**
+ * Created by Qzmo on 2023/5/15
+ */
+public interface PlanExecutionContextProvider {
+    List<PlanExecutionContext> buildContext(ReplayPlan plan);
+
+    void onBeforeContextExecution(PlanExecutionContext currentContext, ReplayPlan plan);
+    void onAfterContextExecution(PlanExecutionContext currentContext, ReplayPlan plan);
+}

--- a/src/main/java/com/arextest/schedule/progress/ProgressTracer.java
+++ b/src/main/java/com/arextest/schedule/progress/ProgressTracer.java
@@ -1,6 +1,7 @@
 package com.arextest.schedule.progress;
 
 import com.arextest.schedule.model.ReplayActionCaseItem;
+import com.arextest.schedule.model.ReplayActionItem;
 import com.arextest.schedule.model.ReplayPlan;
 
 /**
@@ -11,6 +12,8 @@ public interface ProgressTracer {
     void initTotal(ReplayPlan replayPlan);
 
     void finishOne(ReplayActionCaseItem caseItem);
+
+    void finishCaseByAction(ReplayActionItem actionItem);
 
     double finishPercent(String planId);
 

--- a/src/main/java/com/arextest/schedule/progress/impl/RedisProgressTracerImpl.java
+++ b/src/main/java/com/arextest/schedule/progress/impl/RedisProgressTracerImpl.java
@@ -90,8 +90,14 @@ final class RedisProgressTracerImpl implements ProgressTracer {
     @Override
     public void finishOne(ReplayActionCaseItem caseItem) {
         ReplayActionItem replayActionItem = caseItem.getParent();
-        doReplayActionFinish(replayActionItem);
-        ReplayPlan replayPlan = replayActionItem.getParent();
+        finishCaseByAction(replayActionItem);
+    }
+
+    // todo batch finish cases
+    @Override
+    public void finishCaseByAction(ReplayActionItem actionItem) {
+        doReplayActionFinish(actionItem);
+        ReplayPlan replayPlan = actionItem.getParent();
         doPlanFinish(replayPlan);
         this.refreshUpdateTime(replayPlan.getId());
     }

--- a/src/main/java/com/arextest/schedule/sender/ReplaySender.java
+++ b/src/main/java/com/arextest/schedule/sender/ReplaySender.java
@@ -21,11 +21,6 @@ public interface ReplaySender {
     boolean send(ReplayActionCaseItem caseItem);
 
     /**
-     * Try to send the replay case to remote target host with extra headers
-     */
-    boolean send(ReplayActionCaseItem caseItem, Map<String, String> headers);
-
-    /**
      * Try to send the request message to remote target host
      */
     ReplaySendResult send(SenderParameters senderParameters);

--- a/src/main/java/com/arextest/schedule/sender/ReplaySender.java
+++ b/src/main/java/com/arextest/schedule/sender/ReplaySender.java
@@ -24,11 +24,6 @@ public interface ReplaySender {
     ReplaySendResult send(SenderParameters senderParameters);
 
     /**
-     * Try to prepare the replay case remote dependency such as resume config files
-     */
-    boolean prepareRemoteDependency(ReplayActionCaseItem caseItem);
-
-    /**
      * Try to warm up the remote target service before sending
      */
     default boolean activeRemoteService(ReplayActionCaseItem caseItem) {

--- a/src/main/java/com/arextest/schedule/sender/ReplaySender.java
+++ b/src/main/java/com/arextest/schedule/sender/ReplaySender.java
@@ -2,6 +2,8 @@ package com.arextest.schedule.sender;
 
 import com.arextest.schedule.model.ReplayActionCaseItem;
 
+import java.util.Map;
+
 /**
  * @author jmo
  * @since 2021/9/16
@@ -17,6 +19,11 @@ public interface ReplaySender {
      * Try to send the replay case to remote target host
      */
     boolean send(ReplayActionCaseItem caseItem);
+
+    /**
+     * Try to send the replay case to remote target host with extra headers
+     */
+    boolean send(ReplayActionCaseItem caseItem, Map<String, String> headers);
 
     /**
      * Try to send the request message to remote target host

--- a/src/main/java/com/arextest/schedule/sender/ReplaySenderParameters.java
+++ b/src/main/java/com/arextest/schedule/sender/ReplaySenderParameters.java
@@ -1,5 +1,6 @@
 package com.arextest.schedule.sender;
 
+import com.arextest.schedule.model.plan.BuildReplayPlanType;
 import lombok.Data;
 
 import java.util.Map;
@@ -20,4 +21,5 @@ public class ReplaySenderParameters implements SenderParameters {
     private Map<String, String> headers;
     private String recordId;
     private String method;
+    private BuildReplayPlanType replayPlanType;
 }

--- a/src/main/java/com/arextest/schedule/sender/SenderParameters.java
+++ b/src/main/java/com/arextest/schedule/sender/SenderParameters.java
@@ -1,5 +1,7 @@
 package com.arextest.schedule.sender;
 
+import com.arextest.schedule.model.plan.BuildReplayPlanType;
+
 import java.util.Map;
 
 /**
@@ -33,6 +35,10 @@ public interface SenderParameters {
     default String getRecordId() {
         return null;
     }
+
+    default BuildReplayPlanType getReplayPlanType() {
+        return BuildReplayPlanType.BY_APP_ID;
+    };
 
     Map<String, String> getHeaders();
 }

--- a/src/main/java/com/arextest/schedule/sender/impl/DubboReplaySender.java
+++ b/src/main/java/com/arextest/schedule/sender/impl/DubboReplaySender.java
@@ -57,10 +57,6 @@ public class DubboReplaySender extends AbstractReplaySender {
     public ReplaySendResult send(SenderParameters senderParameters) {
         return null;
     }
-    @Override
-    public boolean prepareRemoteDependency(ReplayActionCaseItem caseItem) {
-        return false;
-    }
 
     private boolean doSend(ReplayActionCaseItem caseItem, Map<String, String> headers) {
         ImmutablePair<String, String> interfaceNameAndMethod =

--- a/src/main/java/com/arextest/schedule/sender/impl/DubboReplaySender.java
+++ b/src/main/java/com/arextest/schedule/sender/impl/DubboReplaySender.java
@@ -54,6 +54,11 @@ public class DubboReplaySender extends AbstractReplaySender {
     }
 
     @Override
+    public boolean send(ReplayActionCaseItem caseItem, Map<String, String> headers) {
+        return this.send(caseItem);
+    }
+
+    @Override
     public ReplaySendResult send(SenderParameters senderParameters) {
         return null;
     }

--- a/src/main/java/com/arextest/schedule/sender/impl/DubboReplaySender.java
+++ b/src/main/java/com/arextest/schedule/sender/impl/DubboReplaySender.java
@@ -54,11 +54,6 @@ public class DubboReplaySender extends AbstractReplaySender {
     }
 
     @Override
-    public boolean send(ReplayActionCaseItem caseItem, Map<String, String> headers) {
-        return this.send(caseItem);
-    }
-
-    @Override
     public ReplaySendResult send(SenderParameters senderParameters) {
         return null;
     }

--- a/src/main/java/com/arextest/schedule/sender/impl/HttpServletReplaySender.java
+++ b/src/main/java/com/arextest/schedule/sender/impl/HttpServletReplaySender.java
@@ -31,7 +31,7 @@ import java.util.regex.Pattern;
 
 @Slf4j
 @Component
-final class HttpServletReplaySender extends AbstractReplaySender {
+public final class HttpServletReplaySender extends AbstractReplaySender {
     @Resource
     private HttpWepServiceApiClient httpWepServiceApiClient;
 

--- a/src/main/java/com/arextest/schedule/sender/impl/HttpServletReplaySender.java
+++ b/src/main/java/com/arextest/schedule/sender/impl/HttpServletReplaySender.java
@@ -124,6 +124,11 @@ final class HttpServletReplaySender extends AbstractReplaySender {
         return doSend(replayActionItem, caseItem, headers);
     }
 
+    @Override
+    public boolean send(ReplayActionCaseItem caseItem, Map<String, String> headers) {
+        return doSend(caseItem.getParent(), caseItem, headers);
+    }
+
     private String contactUrl(String baseUrl, String operation) {
         String result = null;
         if (StringUtils.endsWith(baseUrl, "/") || StringUtils.startsWith(operation, "/")) {

--- a/src/main/java/com/arextest/schedule/sender/impl/HttpServletReplaySender.java
+++ b/src/main/java/com/arextest/schedule/sender/impl/HttpServletReplaySender.java
@@ -59,10 +59,9 @@ public final class HttpServletReplaySender extends AbstractReplaySender {
         if (StringUtils.isBlank(senderParameters.getUrl())) {
             return ReplaySendResult.failed("url is null or empty");
         }
-        before(senderParameters.getRecordId(), BuildReplayPlanType.BY_APP_ID.getValue());
+        before(senderParameters.getRecordId(), senderParameters.getReplayPlanType().getValue());
         return doInvoke(senderParameters);
     }
-
 
     private boolean doSend(ReplayActionItem replayActionItem, ReplayActionCaseItem caseItem,
                            Map<String, String> headers) {

--- a/src/main/java/com/arextest/schedule/sender/impl/HttpServletReplaySender.java
+++ b/src/main/java/com/arextest/schedule/sender/impl/HttpServletReplaySender.java
@@ -124,11 +124,6 @@ public final class HttpServletReplaySender extends AbstractReplaySender {
         return doSend(replayActionItem, caseItem, headers);
     }
 
-    @Override
-    public boolean send(ReplayActionCaseItem caseItem, Map<String, String> headers) {
-        return doSend(caseItem.getParent(), caseItem, headers);
-    }
-
     private String contactUrl(String baseUrl, String operation) {
         String result = null;
         if (StringUtils.endsWith(baseUrl, "/") || StringUtils.startsWith(operation, "/")) {

--- a/src/main/java/com/arextest/schedule/sender/impl/HttpServletReplaySender.java
+++ b/src/main/java/com/arextest/schedule/sender/impl/HttpServletReplaySender.java
@@ -47,22 +47,6 @@ final class HttpServletReplaySender extends AbstractReplaySender {
     }
 
     @Override
-    public boolean prepareRemoteDependency(ReplayActionCaseItem caseItem) {
-        Map<String, String> headers = newHeadersIfEmpty(caseItem.requestHeaders());
-        headers.put(CommonConstant.CONFIG_VERSION_HEADER_NAME, caseItem.replayDependency());
-        headers.put(CommonConstant.AREX_RECORD_ID, caseItem.getRecordId());
-        int instanceSize = caseItem.getParent().getTargetInstance().size();
-        boolean allSuccess = true;
-        for (int i = 0; i < instanceSize; i++) {
-            caseItem.setId(String.valueOf(i));
-            boolean prepareSuccess = doSend(caseItem.getParent(), caseItem, headers) || doSend(caseItem.getParent(), caseItem,
-                    headers);
-            allSuccess = allSuccess && prepareSuccess;
-        }
-        return allSuccess;
-    }
-
-    @Override
     public boolean activeRemoteService(ReplayActionCaseItem caseItem) {
         Map<String, String> headers = newHeadersIfEmpty(caseItem.requestHeaders());
         headers.put(CommonConstant.AREX_REPLAY_WARM_UP, Boolean.TRUE.toString());

--- a/src/main/java/com/arextest/schedule/service/AsyncSendCaseTaskRunnable.java
+++ b/src/main/java/com/arextest/schedule/service/AsyncSendCaseTaskRunnable.java
@@ -38,6 +38,10 @@ final class AsyncSendCaseTaskRunnable extends AbstractTracedRunnable {
         boolean success = false;
         Throwable t = null;
         try {
+            if (this.limiter.failBreak()) {
+                return;
+            }
+
             MDCTracer.addDetailId(caseItem.getId());
             long caseExecutionStartMillis = System.currentTimeMillis();
             caseItem.setExecutionStartMillis(caseExecutionStartMillis);

--- a/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
+++ b/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
@@ -201,7 +201,7 @@ public final class PlanConsumeService {
         boolean isFirst = true;
         while (true) {
             sourceItemList = replayActionCaseItemRepository.waitingSendList(replayActionItem.getId(),
-                    CommonConstant.MAX_PAGE_SIZE, executionContext.getContextCaceQuery());
+                    CommonConstant.MAX_PAGE_SIZE, executionContext.getContextCaseQuery());
 
             replayActionItem.setCaseItemList(sourceItemList);
             if (CollectionUtils.isEmpty(sourceItemList)) {

--- a/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
+++ b/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
@@ -71,7 +71,8 @@ public final class PlanConsumeService {
             replayPlan.setExecutionContexts(planExecutionContextProvider.buildContext(replayPlan));
             if (CollectionUtils.isEmpty(replayPlan.getExecutionContexts())) {
                 LOGGER.error("Invalid context built for plan {}", replayPlan);
-                progressEvent.onReplayPlanFinish(replayPlan, ReplayStatusType.FAIL_INTERRUPTED);
+                replayPlan.setErrorMessage("Got empty execution context");
+                progressEvent.onReplayPlanInterrupt(replayPlan, ReplayStatusType.FAIL_INTERRUPTED);
                 return;
             }
 

--- a/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
+++ b/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
@@ -117,9 +117,8 @@ public final class PlanConsumeService {
         progressTracer.initTotal(replayPlan);
 
         // limiter share for entire plan, TODO: limiter for each service instance
-        final SendSemaphoreLimiter qpsLimiter = new SendSemaphoreLimiter();
+        final SendSemaphoreLimiter qpsLimiter = new SendSemaphoreLimiter(replayPlan.getReplaySendMaxQps());
         qpsLimiter.setTotalTasks(replayPlan.getCaseTotalCount());
-        qpsLimiter.setSendMaxRate(replayPlan.getReplaySendMaxQps());
 
         ExecutionStatus lastResult = ExecutionStatus.buildNormal();
 

--- a/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
+++ b/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
@@ -65,12 +65,6 @@ public final class PlanConsumeService {
         @SuppressWarnings("unchecked")
         protected void doWithTracedRunning() {
             int planSavedCaseSize = saveActionCaseToSend(replayPlan);
-
-            if (planSavedCaseSize == 0) {
-                progressEvent.onReplayPlanFinish(replayPlan);
-                return;
-            }
-
             replayPlan.setExecutionContexts(planExecutionContextProvider.buildContext(replayPlan));
             if (CollectionUtils.isEmpty(replayPlan.getExecutionContexts())) {
                 LOGGER.error("Invalid context built for plan {}", replayPlan);
@@ -80,6 +74,10 @@ public final class PlanConsumeService {
 
             sendAllActionCase(replayPlan);
 
+            // empty items are not able to trigger plan finished hook
+            if (planSavedCaseSize == 0) {
+                progressEvent.onReplayPlanFinish(replayPlan);
+            }
         }
     }
 

--- a/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
+++ b/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
@@ -130,6 +130,7 @@ public final class PlanConsumeService {
         for (PlanExecutionContext executionContext : replayPlan.getExecutionContexts()) {
             executionContext.setExecutionStatus(sendResult);
             planExecutionContextProvider.onBeforeContextExecution(executionContext, replayPlan);
+
             List<CompletableFuture<Void>> contextTasks = new ArrayList<>();
             for (ReplayActionItem replayActionItem : replayPlan.getReplayActionItemList()) {
                 if (!replayActionItem.isProcessed()) {

--- a/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
+++ b/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
@@ -28,6 +28,7 @@ import static com.arextest.schedule.common.CommonConstant.PINNED;
  */
 @Slf4j
 @Service
+@SuppressWarnings("rawtypes")
 public final class PlanConsumeService {
     @Resource
     private ReplayCaseRemoteLoadService caseRemoteLoadService;
@@ -61,6 +62,7 @@ public final class PlanConsumeService {
         }
 
         @Override
+        @SuppressWarnings("unchecked")
         protected void doWithTracedRunning() {
             int planSavedCaseSize = saveActionCaseToSend(replayPlan);
 
@@ -115,6 +117,7 @@ public final class PlanConsumeService {
         return planSavedCaseSize;
     }
 
+    @SuppressWarnings("unchecked")
     private void sendAllActionCase(ReplayPlan replayPlan) {
         progressTracer.initTotal(replayPlan);
 

--- a/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
+++ b/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
@@ -6,12 +6,6 @@ import com.arextest.schedule.dao.mongodb.ReplayActionCaseItemRepository;
 import com.arextest.schedule.dao.mongodb.ReplayPlanRepository;
 import com.arextest.schedule.mdc.AbstractTracedRunnable;
 import com.arextest.schedule.mdc.MDCTracer;
-import com.arextest.schedule.model.CaseSendStatusType;
-import com.arextest.schedule.model.LogType;
-import com.arextest.schedule.model.ReplayActionCaseItem;
-import com.arextest.schedule.model.ReplayActionItem;
-import com.arextest.schedule.model.ReplayPlan;
-import com.arextest.schedule.model.ReplayStatusType;
 import com.arextest.schedule.model.*;
 import com.arextest.schedule.planexecution.PlanExecutionContextProvider;
 import com.arextest.schedule.progress.ProgressEvent;
@@ -25,8 +19,8 @@ import javax.annotation.Resource;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 
 /**
  * @author jmo

--- a/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
+++ b/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
@@ -78,7 +78,7 @@ public final class PlanConsumeService {
 
             sendAllActionCase(replayPlan);
 
-            // empty items are not able to trigger plan finished hook
+            // actionItems with empty case item are not able to trigger plan finished hook
             if (planSavedCaseSize == 0) {
                 progressEvent.onReplayPlanFinish(replayPlan);
             }

--- a/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
+++ b/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
@@ -123,7 +123,7 @@ public final class PlanConsumeService {
     private void sendAllActionCase(ReplayPlan replayPlan) {
         progressTracer.initTotal(replayPlan);
 
-        // limiter share for entire plan, TODO: limiter for each service instance
+        // limiter shared for entire plan
         final SendSemaphoreLimiter qpsLimiter = new SendSemaphoreLimiter(replayPlan.getReplaySendMaxQps());
         qpsLimiter.setTotalTasks(replayPlan.getCaseTotalCount());
 

--- a/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
+++ b/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
@@ -148,6 +148,8 @@ public final class PlanConsumeService {
                 }
 
                 if (replayActionItem.finished() || replayActionItem.isEmpty()) {
+                    LOGGER.warn("Skipped action item: {}, finished: {}, empty: {}",
+                            replayActionItem.getAppId(), replayActionItem.finished(), replayActionItem.isEmpty());
                     continue;
                 }
                 CompletableFuture<Void> task = CompletableFuture.runAsync(

--- a/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
+++ b/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
@@ -229,8 +229,6 @@ public final class PlanConsumeService {
 
     private int streamingCaseItemSave(ReplayActionItem replayActionItem) {
         List<ReplayActionCaseItem> caseItemList = replayActionItem.getCaseItemList();
-        // to provide necessary fields into case item for context to consume when sending
-        planExecutionContextProvider.injectContextIntoCase(caseItemList);
         int size;
         if (CollectionUtils.isNotEmpty(caseItemList)) {
             size = doFixedCaseSave(caseItemList);
@@ -241,6 +239,7 @@ public final class PlanConsumeService {
     }
 
     private int doFixedCaseSave(List<ReplayActionCaseItem> caseItemList) {
+        caseItemPostProcess(caseItemList);
         int size = 0;
         for (int i = 0; i < caseItemList.size(); i++) {
             ReplayActionCaseItem caseItem = caseItemList.get(i);
@@ -255,6 +254,11 @@ public final class PlanConsumeService {
         }
         replayActionCaseItemRepository.save(caseItemList);
         return size;
+    }
+
+    private void caseItemPostProcess(List<ReplayActionCaseItem> caseItemList) {
+        // to provide necessary fields into case item for context to consume when sending
+        planExecutionContextProvider.injectContextIntoCase(caseItemList);
     }
 
     /**
@@ -280,6 +284,7 @@ public final class PlanConsumeService {
             if (CollectionUtils.isEmpty(caseItemList)) {
                 break;
             }
+            caseItemPostProcess(caseItemList);
             ReplayParentBinder.setupCaseItemParent(caseItemList, replayActionItem);
             totalSize += caseItemList.size();
             beginTimeMills = caseItemList.get(caseItemList.size() - 1).getRecordTime();

--- a/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
+++ b/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
@@ -207,6 +207,7 @@ public final class PlanConsumeService {
             case INTERRUPT_CASES_OF_CONTEXT:
                 // skip all cases of this context leaving the status as default
                 sendResult.setCanceled(replayCaseTransmitService.releaseAllCases(replayActionItem));
+                sendResult.setInterrupted(replayActionItem.getSendRateLimiter().failBreak());
                 break;
 
             case NORMAL:

--- a/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
+++ b/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
@@ -122,8 +122,10 @@ public final class PlanConsumeService {
     private void sendAllActionCase(ReplayPlan replayPlan) {
         progressTracer.initTotal(replayPlan);
 
-        // limiter shared for entire plan
-        final SendSemaphoreLimiter qpsLimiter = new SendSemaphoreLimiter(replayPlan.getReplaySendMaxQps());
+        // limiter shared for entire plan, max qps = maxQps per instance * min instance count
+        final SendSemaphoreLimiter qpsLimiter = new SendSemaphoreLimiter(
+                replayPlan.getReplaySendMaxQps() * replayPlan.getMinInstanceCount());
+
         qpsLimiter.setTotalTasks(replayPlan.getCaseTotalCount());
 
         ExecutionStatus sendResult = ExecutionStatus.buildNormal();

--- a/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
+++ b/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
@@ -206,7 +206,7 @@ public final class PlanConsumeService {
         switch (executionContext.getActionType()) {
             case INTERRUPT_CASES_OF_CONTEXT:
                 // skip all cases of this context leaving the status as default
-                sendResult.setCanceled(replayCaseTransmitService.releaseAllCases(replayActionItem));
+                sendResult.setCanceled(replayCaseTransmitService.releaseCasesOfContext(replayActionItem, executionContext));
                 sendResult.setInterrupted(replayActionItem.getSendRateLimiter().failBreak());
                 break;
 

--- a/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
+++ b/src/main/java/com/arextest/schedule/service/PlanConsumeService.java
@@ -63,6 +63,7 @@ public final class PlanConsumeService {
         @Override
         protected void doWithTracedRunning() {
             int planSavedCaseSize = saveActionCaseToSend(replayPlan);
+
             if (planSavedCaseSize == 0) {
                 progressEvent.onReplayPlanFinish(replayPlan);
                 return;
@@ -76,6 +77,7 @@ public final class PlanConsumeService {
             }
 
             sendAllActionCase(replayPlan);
+
         }
     }
 

--- a/src/main/java/com/arextest/schedule/service/PlanProduceService.java
+++ b/src/main/java/com/arextest/schedule/service/PlanProduceService.java
@@ -136,6 +136,8 @@ public class PlanProduceService {
         } else {
             replayPlan.setCaseCountLimit(request.getCaseCountLimit());
         }
+
+        replayPlan.setMinInstanceCount(planContext.determineMinInstanceCount());
         return replayPlan;
     }
 

--- a/src/main/java/com/arextest/schedule/service/ReplayCaseTransmitService.java
+++ b/src/main/java/com/arextest/schedule/service/ReplayCaseTransmitService.java
@@ -74,7 +74,7 @@ public class ReplayCaseTransmitService {
         if (isFirst) {
             activeRemoteHost(sourceItemList);
         }
-        replayActionItem.getSendRateLimiter().reset();
+        // replayActionItem.getSendRateLimiter().reset();
         byte[] cancelKey = getCancelKey(replayActionItem.getPlanId());
 
         if (replayActionItem.getSendRateLimiter().failBreak()) {

--- a/src/main/java/com/arextest/schedule/service/ReplayCaseTransmitService.java
+++ b/src/main/java/com/arextest/schedule/service/ReplayCaseTransmitService.java
@@ -204,7 +204,10 @@ public class ReplayCaseTransmitService {
         }
 
         try {
-            groupSentLatch.await(GROUP_SENT_WAIT_TIMEOUT, TimeUnit.SECONDS);
+            boolean clear = groupSentLatch.await(GROUP_SENT_WAIT_TIMEOUT, TimeUnit.SECONDS);
+            if (!clear) {
+                LOGGER.error("Send group failed to await all request of batch");
+            }
         } catch (InterruptedException e) {
             LOGGER.error("send group to remote host error:{}", e.getMessage(), e);
         }

--- a/src/main/java/com/arextest/schedule/service/ReplayCaseTransmitService.java
+++ b/src/main/java/com/arextest/schedule/service/ReplayCaseTransmitService.java
@@ -18,7 +18,6 @@ import com.arextest.schedule.sender.ReplaySender;
 import com.arextest.schedule.sender.ReplaySenderFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.netty.util.internal.MathUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -113,8 +112,12 @@ public class ReplayCaseTransmitService {
         replayActionItem.getSendRateLimiter().batchRelease(false, contextCasesCount);
 
         // if we skip the rest of cases remaining in the action item, set its status
-        if (MathUtil.compare(replayActionItem.getReplayCaseCount(), replayActionItem.getCaseProcessCount()) == 0) {
+        if (Integer.valueOf(replayActionItem.getReplayCaseCount()).equals(replayActionItem.getCaseProcessCount())) {
             progressEvent.onActionInterrupted(replayActionItem);
+        } else {
+            for (int i = 0; i < contextCasesCount; i++) {
+                progressTracer.finishCaseByAction(replayActionItem);
+            }
         }
 
         return false;

--- a/src/main/java/com/arextest/schedule/service/ReplayCaseTransmitService.java
+++ b/src/main/java/com/arextest/schedule/service/ReplayCaseTransmitService.java
@@ -87,7 +87,7 @@ public class ReplayCaseTransmitService {
             LOGGER.error("do send error:{}", throwable.getMessage(), throwable);
             markAllSendStatus(sourceItemList, CaseSendStatusType.EXCEPTION_FAILED);
         } finally {
-            replayActionItem.setCaseProcessCount(replayActionItem.getReplayCaseCount() + sourceItemList.size());
+            replayActionItem.recordProcessCaseCount(sourceItemList.size());
         }
 
         return false;
@@ -109,7 +109,7 @@ public class ReplayCaseTransmitService {
         int contextCasesCount = (int) replayActionCaseItemRepository.countWaitingSendList(replayActionItem.getId(),
                 executionContext.getContextCaseQuery());
 
-        replayActionItem.setCaseProcessCount(replayActionItem.getReplayCaseCount() + contextCasesCount);
+        replayActionItem.recordProcessCaseCount(contextCasesCount);
         replayActionItem.getSendRateLimiter().batchRelease(false, contextCasesCount);
 
         // if we skip the rest of cases remaining in the action item, set its status

--- a/src/main/java/com/arextest/schedule/service/ReplayCaseTransmitService.java
+++ b/src/main/java/com/arextest/schedule/service/ReplayCaseTransmitService.java
@@ -171,6 +171,12 @@ public class ReplayCaseTransmitService {
                 doSendFailedAsFinish(replayActionCaseItem, CaseSendStatusType.EXCEPTION_FAILED);
             }
         }
+
+        try {
+            groupSentLatch.await(GROUP_SENT_WAIT_TIMEOUT, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            LOGGER.error("send group to remote host error:{}", e.getMessage(), e);
+        }
         MDCTracer.removeDetailId();
     }
 

--- a/src/main/java/com/arextest/schedule/service/ReplayCaseTransmitService.java
+++ b/src/main/java/com/arextest/schedule/service/ReplayCaseTransmitService.java
@@ -66,15 +66,17 @@ public class ReplayCaseTransmitService {
     @Resource
     private MetricService metricService;
 
-    public boolean send(ReplayActionItem replayActionItem, boolean isFirst) {
+    public boolean send(ReplayActionItem replayActionItem) {
         List<ReplayActionCaseItem> sourceItemList = replayActionItem.getCaseItemList();
         if (CollectionUtils.isEmpty(sourceItemList)) {
             return false;
         }
-        if (isFirst) {
+
+        // warmUp should be done once for each endpoint
+        if (!replayActionItem.isProcessed()) {
             activeRemoteHost(sourceItemList);
         }
-        // replayActionItem.getSendRateLimiter().reset();
+
         byte[] cancelKey = getCancelKey(replayActionItem.getPlanId());
 
         if (replayActionItem.getSendRateLimiter().failBreak()) {

--- a/src/main/java/com/arextest/schedule/service/ReplayCaseTransmitService.java
+++ b/src/main/java/com/arextest/schedule/service/ReplayCaseTransmitService.java
@@ -153,6 +153,11 @@ public class ReplayCaseTransmitService {
         final SendSemaphoreLimiter semaphore = actionItem.getSendRateLimiter();
         final CountDownLatch groupSentLatch = new CountDownLatch(valueSize);
         for (int i = 0; i < valueSize; i++) {
+            if (semaphore.failBreak()) {
+                groupSentLatch.countDown();
+                continue;
+            }
+
             ReplayActionCaseItem replayActionCaseItem = values.get(i);
             MDCTracer.addDetailId(caseItem.getId());
             try {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,3 +21,5 @@ arex.report.config.application.url=${arex.report.service.api}/api/config/applica
 #for web connect
 arex.connect.time.out=10000
 arex.read.time.out=10000
+
+arex.schedule.pool.io.cpuratio=4


### PR DESCRIPTION
Main changes:

1. Remove ReplaySender#prepareDependency
2. Add PlanExecutionContextProvider, dependencies preparing should be done here
3. Change the behavious of SendSemaphoreLimiter, see comments of the class for details
4. Allow multiple actionItem to be handled concurrently