### PR TITLE
refactor: extract interface for self-healing executors

### DIFF
--- a/src/main/java/com/arextest/schedule/dao/mongodb/ReplayPlanRepository.java
+++ b/src/main/java/com/arextest/schedule/dao/mongodb/ReplayPlanRepository.java
@@ -65,5 +65,4 @@ public class ReplayPlanRepository implements RepositoryField {
         List<ReplayPlanCollection> replayPlanCollections = mongoTemplate.find(query, ReplayPlanCollection.class);
         return replayPlanCollections.stream().map(ReplayPlanConverter.INSTANCE::dtoFromDao).collect(Collectors.toList());
     }
-
 }

--- a/src/main/java/com/arextest/schedule/resume/SelfHealingExecutor.java
+++ b/src/main/java/com/arextest/schedule/resume/SelfHealingExecutor.java
@@ -9,6 +9,10 @@ import java.util.List;
  * Created by Qzmo on 2023/5/24
  */
 public interface SelfHealingExecutor {
+    /**
+     * Query plans created between [now-offset-max   to  now-offset] and have not been finished correctly
+     * @return A list of timeout plans
+     */
     List<ReplayPlan> queryTimeoutPlan(Duration offsetDuration, Duration maxDuration);
 
     /**

--- a/src/main/java/com/arextest/schedule/resume/SelfHealingExecutor.java
+++ b/src/main/java/com/arextest/schedule/resume/SelfHealingExecutor.java
@@ -1,0 +1,18 @@
+package com.arextest.schedule.resume;
+
+import com.arextest.schedule.model.ReplayPlan;
+
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * Created by Qzmo on 2023/5/24
+ */
+public interface SelfHealingExecutor {
+    List<ReplayPlan> queryTimeoutPlan(Duration offsetDuration, Duration maxDuration);
+
+    /**
+     * Resume single replay plan
+     */
+    void doResume(ReplayPlan replayPlan);
+}


### PR DESCRIPTION
Major changes

1. Extracted interface for self-healing executor
2. Make doResume public, allowing users to implement their own query for timeout plans and call doResume