### PR TITLE
refactor: rerun loads case from mocker table

### DIFF
--- a/arex-schedule-web-api/pom.xml
+++ b/arex-schedule-web-api/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>com.arextest</groupId>
         <artifactId>arex-schedule-parent</artifactId>
-        <version>1.0.38.1</version>
+        <version>1.0.38.2</version>
     </parent>
     <packaging>${packagingType}</packaging>
     <artifactId>arex-schedule-web-api</artifactId>
-    <version>1.0.38.1</version>
+    <version>1.0.38.2</version>
 
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/arex-schedule-web-api/src/main/java/com/arextest/schedule/dao/mongodb/ReplayActionCaseItemRepository.java
+++ b/arex-schedule-web-api/src/main/java/com/arextest/schedule/dao/mongodb/ReplayActionCaseItemRepository.java
@@ -10,6 +10,7 @@ import com.arextest.schedule.model.dao.mongodb.ReplayRunDetailsCollection;
 import com.mongodb.client.result.UpdateResult;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
 import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.annotation.Id;
@@ -22,7 +23,6 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Repository;
-import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 import javax.annotation.Resource;
@@ -205,20 +205,8 @@ public class ReplayActionCaseItemRepository implements RepositoryWriter<ReplayAc
                 ReplayRunDetailsCollection.class, String.class));
     }
 
-    public Set<String> getAllContextIdentifiers(List<String> caseIds) {
-        Query query = Query.query(Criteria.where(ReplayActionCaseItem.FIELD_ID).in(caseIds));
-        return new HashSet<>(mongoTemplate.findDistinct(query, ReplayActionCaseItem.FIELD_CONTEXT_IDENTIFIER,
-                ReplayRunDetailsCollection.class, String.class));
-    }
-
     public boolean hasNullIdentifier(String planId) {
         Query query = Query.query(Criteria.where(ReplayActionCaseItem.FIELD_PLAN_ID).is(planId));
-        query.addCriteria(Criteria.where(ReplayActionCaseItem.FIELD_CONTEXT_IDENTIFIER).isNull());
-        return mongoTemplate.exists(query, ReplayRunDetailsCollection.class);
-    }
-
-    public boolean hasNullIdentifier(List<String> caseIds) {
-        Query query = Query.query(Criteria.where(ReplayActionCaseItem.FIELD_ID).in(caseIds));
         query.addCriteria(Criteria.where(ReplayActionCaseItem.FIELD_CONTEXT_IDENTIFIER).isNull());
         return mongoTemplate.exists(query, ReplayRunDetailsCollection.class);
     }

--- a/arex-schedule-web-api/src/main/java/com/arextest/schedule/model/PlanExecutionContext.java
+++ b/arex-schedule-web-api/src/main/java/com/arextest/schedule/model/PlanExecutionContext.java
@@ -26,7 +26,4 @@ public class PlanExecutionContext<T> {
 
     @JsonIgnore
     private T dependencies;
-
-    @JsonIgnore
-    private String contextIdentifier;
 }

--- a/arex-schedule-web-api/src/main/java/com/arextest/schedule/model/ReplayActionItem.java
+++ b/arex-schedule-web-api/src/main/java/com/arextest/schedule/model/ReplayActionItem.java
@@ -69,6 +69,7 @@ public class ReplayActionItem {
     @JsonIgnore
     private ServiceInstanceOperation mappedInstanceOperation;
     private int replayCaseCount;
+    private int rerunCaseCount;
     private String appId;
     private Set<String> operationTypes;
     /**

--- a/arex-schedule-web-api/src/main/java/com/arextest/schedule/progress/impl/RedisProgressTracerImpl.java
+++ b/arex-schedule-web-api/src/main/java/com/arextest/schedule/progress/impl/RedisProgressTracerImpl.java
@@ -196,7 +196,7 @@ final class RedisProgressTracerImpl implements ProgressTracer {
             doWithRetry(() -> redisCacheProvider.decrValueBy(toPlanFinishKeyBytes(planId), replayPlan.getReRunCaseCount()));
             replayPlan.getReplayActionItemList().forEach(replayActionItem ->
                 doWithRetry(() -> redisCacheProvider.incrValueBy(toPlanActionTotalKeyBytes(replayActionItem.getId()),
-                replayActionItem.getCaseItemList().size())));
+                replayActionItem.getRerunCaseCount())));
         } catch (Throwable throwable) {
             LOGGER.error("reRunPlan decrValue error!msg: {} ,plan id: {}, error:{}", throwable.getMessage(), planId,
                 throwable);

--- a/arex-schedule-web-api/src/main/java/com/arextest/schedule/progress/impl/UpdateResultProgressEventImpl.java
+++ b/arex-schedule-web-api/src/main/java/com/arextest/schedule/progress/impl/UpdateResultProgressEventImpl.java
@@ -47,6 +47,7 @@ public class UpdateResultProgressEventImpl implements ProgressEvent {
     @Override
     public void onReplayPlanReRunException(ReplayPlan plan, Throwable t) {
         replayReportService.pushPlanStatus(plan.getId(), ReplayStatusType.FAIL_INTERRUPTED, t.getMessage(), true);
+        redisCacheProvider.remove(PlanProduceService.buildPlanRunningRedisKey(plan.getId()));
     }
 
     @Override

--- a/arex-schedule-web-api/src/main/java/com/arextest/schedule/resume/SelfHealingExecutorImpl.java
+++ b/arex-schedule-web-api/src/main/java/com/arextest/schedule/resume/SelfHealingExecutorImpl.java
@@ -75,8 +75,7 @@ public class SelfHealingExecutorImpl implements SelfHealingExecutor {
     }
 
     public List<ReplayPlan> queryTimeoutPlan(Duration offsetDuration, Duration maxDuration) {
-        return replayPlanRepository.timeoutPlanList(offsetDuration, maxDuration).stream()
-            .filter(plan -> !plan.isReRun()).collect(Collectors.toList());
+        return replayPlanRepository.timeoutPlanList(offsetDuration, maxDuration);
     }
 
     public void doResume(ReplayPlan replayPlan) {

--- a/arex-schedule-web-api/src/main/java/com/arextest/schedule/service/PlanProduceService.java
+++ b/arex-schedule-web-api/src/main/java/com/arextest/schedule/service/PlanProduceService.java
@@ -333,8 +333,9 @@ public class PlanProduceService {
             progressEvent.onReplayPlanStageUpdate(replayPlan, PlanStageEnum.LOADING_CASE, StageStatusEnum.ONGOING,
                 System.currentTimeMillis(), null, null);
             planConsumePrepareService.updateFailedActionAndCase(replayPlan, failedCaseList);
-
-            planConsumePrepareService.doResumeOperationDescriptor(replayPlan);
+            if (CollectionUtils.isEmpty(replayPlan.getReplayActionItemList())) {
+                throw new RuntimeException("no replayActionItem!");
+            }
             progressEvent.onReplayPlanStageUpdate(replayPlan, PlanStageEnum.LOADING_CASE, StageStatusEnum.SUCCEEDED,
                 null, System.currentTimeMillis(), null);
         } catch (Exception e) {

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </modules>
     <groupId>com.arextest</groupId>
     <artifactId>arex-schedule-parent</artifactId>
-    <version>1.0.38.1</version>
+    <version>1.0.38.2</version>
 
 
     <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
Reduce the special logic of reRunning. Be as compatible with createPlan logic as possible.