### PR TITLE
feat:Reset the operationName of the Database category

### DIFF
--- a/arex-schedule-web-api/pom.xml
+++ b/arex-schedule-web-api/pom.xml
@@ -136,7 +136,7 @@
   <parent>
     <artifactId>arex-schedule-parent</artifactId>
     <groupId>com.arextest</groupId>
-    <version>1.1.29</version>
+    <version>1.1.30</version>
   </parent>
 
   <profiles>
@@ -338,5 +338,5 @@
       </properties>
     </profile>
   </profiles>
-  <version>1.1.29</version>
+  <version>1.1.30</version>
 </project>

--- a/arex-schedule-web-api/src/main/java/com/arextest/schedule/comparer/impl/PrepareCompareItemBuilder.java
+++ b/arex-schedule-web-api/src/main/java/com/arextest/schedule/comparer/impl/PrepareCompareItemBuilder.java
@@ -47,7 +47,7 @@ final class PrepareCompareItemBuilder {
   private String operationName(MockCategoryType categoryType, Target target, String operationName) {
     if (Objects.equals(categoryType, MockCategoryType.DATABASE)) {
       // The "@" in the operationName of DATABASE indicates that the SQL statement has been parsed and returned directly.
-      return operationName.contains("@") ? operationName : target.attributeAsString(MockAttributeNames.DB_NAME);
+      return StringUtils.contains(operationName, "@") ? operationName : target.attributeAsString(MockAttributeNames.DB_NAME);
     }
     if (Objects.equals(categoryType, MockCategoryType.REDIS)) {
       return target.attributeAsString(MockAttributeNames.CLUSTER_NAME);

--- a/arex-schedule-web-api/src/main/java/com/arextest/schedule/comparer/impl/PrepareCompareItemBuilder.java
+++ b/arex-schedule-web-api/src/main/java/com/arextest/schedule/comparer/impl/PrepareCompareItemBuilder.java
@@ -22,7 +22,7 @@ final class PrepareCompareItemBuilder {
 
   CompareItem build(AREXMocker instance) {
     MockCategoryType categoryType = instance.getCategoryType();
-    String operationKey = operationName(categoryType, instance.getTargetRequest());
+    String operationKey = operationName(categoryType, instance.getTargetRequest(), instance.getOperationName());
     if (StringUtils.isEmpty(operationKey)) {
       operationKey = instance.getOperationName();
     }
@@ -44,14 +44,15 @@ final class PrepareCompareItemBuilder {
     return new CompareItemImpl(operationKey, body, compareKey, createTime, entryPointCategory);
   }
 
-  private String operationName(MockCategoryType categoryType, Target target) {
+  private String operationName(MockCategoryType categoryType, Target target, String operationName) {
     if (Objects.equals(categoryType, MockCategoryType.DATABASE)) {
-      return target.attributeAsString(MockAttributeNames.DB_NAME);
+      // The "@" in the operationName of DATABASE indicates that the SQL statement has been parsed and returned directly.
+      return operationName.contains("@") ? operationName : target.attributeAsString(MockAttributeNames.DB_NAME);
     }
     if (Objects.equals(categoryType, MockCategoryType.REDIS)) {
       return target.attributeAsString(MockAttributeNames.CLUSTER_NAME);
     }
-    return null;
+    return operationName;
   }
 
   private ObjectNode buildAttributes(Target target) {

--- a/pom.xml
+++ b/pom.xml
@@ -314,5 +314,5 @@
     <url>https://github.com/arextest/arex-replay-schedule</url>
   </scm>
   <url>https://github.com/arextest/arex-replay-schedule</url>
-  <version>1.1.29</version>
+  <version>1.1.30</version>
 </project>


### PR DESCRIPTION
- When the categoryName in the ReplayCompareResult table is Database, if the operationName of the Mocker contains @, it will be used directly, otherwise dbName will be used