### PR TITLE
feat: Compatible with replayResult interface logic

### DIFF
--- a/arex-schedule-web-api/pom.xml
+++ b/arex-schedule-web-api/pom.xml
@@ -136,7 +136,7 @@
   <parent>
     <artifactId>arex-schedule-parent</artifactId>
     <groupId>com.arextest</groupId>
-    <version>1.2.17</version>
+    <version>1.2.18</version>
   </parent>
 
   <profiles>
@@ -338,5 +338,5 @@
       </properties>
     </profile>
   </profiles>
-  <version>1.2.17</version>
+  <version>1.2.18</version>
 </project>

--- a/arex-schedule-web-api/src/main/java/com/arextest/schedule/client/ZstdJacksonMessageConverter.java
+++ b/arex-schedule-web-api/src/main/java/com/arextest/schedule/client/ZstdJacksonMessageConverter.java
@@ -29,7 +29,7 @@ final class ZstdJacksonMessageConverter extends AbstractHttpMessageConverter<Obj
 
   @Override
   protected boolean supports(Class<?> clazz) {
-    return true;
+    return !(clazz == byte[].class || clazz.isPrimitive());
   }
 
   @Override
@@ -41,6 +41,6 @@ final class ZstdJacksonMessageConverter extends AbstractHttpMessageConverter<Obj
   @Override
   protected void writeInternal(Object o, HttpOutputMessage outputMessage) throws IOException,
       HttpMessageNotWritableException {
-    zstdJacksonSerializer.serializeTo(o, outputMessage.getBody());
+    outputMessage.getBody().write(zstdJacksonSerializer.serialize(o));
   }
 }

--- a/arex-schedule-web-api/src/main/java/com/arextest/schedule/common/JsonUtils.java
+++ b/arex-schedule-web-api/src/main/java/com/arextest/schedule/common/JsonUtils.java
@@ -13,11 +13,20 @@ import org.apache.commons.lang3.StringUtils;
 public class JsonUtils {
   private static final ObjectMapper objectMapper = new ObjectMapper();
 
-  public static  <T> T byteToObject(byte[] bytes, Class<T> tClass) {
+  public static  <T> T byteToObject(byte[] bytes, Class<T> tClazz) {
     try {
-      return objectMapper.readValue(bytes, tClass);
+      return objectMapper.readValue(bytes, tClazz);
     } catch (IOException e) {
       LOGGER.error("byteToObject error:{}", e.getMessage(), e);
+    }
+    return null;
+  }
+
+  public static  <T> T jsonStringToObject(String string, Class<T> tClazz) {
+    try {
+      return objectMapper.readValue(string, tClazz);
+    } catch (IOException e) {
+      LOGGER.error("jsonStringToObject error:{}", e.getMessage(), e);
     }
     return null;
   }
@@ -26,7 +35,7 @@ public class JsonUtils {
     try {
       return objectMapper.writeValueAsString(value);
     } catch (IOException e) {
-      LOGGER.error("byteToObject error:{}", e.getMessage(), e);
+      LOGGER.error("objectToJsonString error:{}", e.getMessage(), e);
     }
     return StringUtils.EMPTY;
   }

--- a/arex-schedule-web-api/src/main/java/com/arextest/schedule/comparer/CategoryComparisonHolder.java
+++ b/arex-schedule-web-api/src/main/java/com/arextest/schedule/comparer/CategoryComparisonHolder.java
@@ -1,6 +1,7 @@
 package com.arextest.schedule.comparer;
 
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 /**
@@ -11,6 +12,22 @@ import lombok.Data;
 public class CategoryComparisonHolder {
 
   private String categoryName;
+  /**
+   * Need to match the comparison relationship
+   */
   private List<CompareItem> record;
   private List<CompareItem> replayResult;
+
+  private Boolean needMatch;
+  /**
+   * Not need to match the comparison relationship
+   */
+  private CompareResultItem compareResultItem;
+
+  @Data
+  @AllArgsConstructor
+  public static class CompareResultItem {
+    CompareItem recordItem;
+    CompareItem replayItem;
+  }
 }

--- a/arex-schedule-web-api/src/main/java/com/arextest/schedule/comparer/converter/CompareItemConvertFactory.java
+++ b/arex-schedule-web-api/src/main/java/com/arextest/schedule/comparer/converter/CompareItemConvertFactory.java
@@ -1,0 +1,26 @@
+package com.arextest.schedule.comparer.converter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.annotation.Resource;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CompareItemConvertFactory {
+  private final Map<String, CompareItemConverter> categoryConverters;
+  @Resource
+  private CompareItemConverter defaultCompareItemConverterImpl;
+
+  public CompareItemConvertFactory(@Autowired List<CompareItemConverter> converters) {
+    this.categoryConverters = converters.stream().filter(c -> StringUtils.isNotBlank(c.getCategoryName()))
+        .collect(Collectors.toMap(CompareItemConverter::getCategoryName, Function.identity()));
+  }
+
+  public CompareItemConverter getConvert(String categoryName) {
+    return categoryConverters.getOrDefault(categoryName, defaultCompareItemConverterImpl);
+  }
+}

--- a/arex-schedule-web-api/src/main/java/com/arextest/schedule/comparer/converter/CompareItemConverter.java
+++ b/arex-schedule-web-api/src/main/java/com/arextest/schedule/comparer/converter/CompareItemConverter.java
@@ -1,0 +1,29 @@
+package com.arextest.schedule.comparer.converter;
+
+import com.arextest.model.mock.AREXMocker;
+import com.arextest.model.replay.CompareRelationResult;
+import com.arextest.schedule.comparer.CompareItem;
+
+public interface CompareItemConverter {
+  String DEFAULT_CATEGORY_NAME = "default";
+
+  default String getCategoryName() {
+    return DEFAULT_CATEGORY_NAME;
+  }
+
+  /**
+   * Convert mocker to compare item, The agent handles the compatibility needs before the match
+   * @param mocker
+   * @return
+   */
+  CompareItem convert(AREXMocker mocker);
+
+  /**
+   * Convert relation result to compare item
+   * @param relationResult
+   * @param recordCompareItem
+   * @return
+   */
+  CompareItem convert(CompareRelationResult relationResult, boolean recordCompareItem);
+
+}

--- a/arex-schedule-web-api/src/main/java/com/arextest/schedule/comparer/converter/impl/DatabaseCompareItemConverterImpl.java
+++ b/arex-schedule-web-api/src/main/java/com/arextest/schedule/comparer/converter/impl/DatabaseCompareItemConverterImpl.java
@@ -1,0 +1,99 @@
+package com.arextest.schedule.comparer.converter.impl;
+
+import com.arextest.model.constants.MockAttributeNames;
+import com.arextest.model.mock.AREXMocker;
+import com.arextest.model.mock.MockCategoryType;
+import com.arextest.model.mock.Mocker.Target;
+import com.arextest.model.replay.CompareRelationResult;
+import com.arextest.schedule.common.JsonUtils;
+import com.arextest.schedule.comparer.CompareItem;
+import com.arextest.schedule.comparer.converter.CompareItemConverter;
+import com.arextest.schedule.comparer.impl.PrepareCompareItemBuilder.CompareItemImpl;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Map;
+import java.util.Map.Entry;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author xinyuan_wang.
+ * @create 2024/9/2 16:46
+ */
+@Slf4j
+@Component
+public class DatabaseCompareItemConverterImpl implements CompareItemConverter {
+
+  @Override
+  public String getCategoryName() {
+    return MockCategoryType.DATABASE.getName();
+  }
+
+  @Override
+  public CompareItem convert(AREXMocker mocker) {
+    if (mocker == null || mocker.getCategoryType() == null) {
+      return null;
+    }
+
+    String operationKey = getOperationName(mocker.getTargetRequest(), mocker.getOperationName());
+    return new CompareItemImpl(operationKey, buildAttributes(mocker.getTargetRequest()).toString(),
+        mocker.getId(), mocker.getCreationTime(), mocker.getCategoryType().isEntryPoint());
+  }
+
+  @Override
+  public CompareItem convert(CompareRelationResult relationResult, boolean recordCompareItem) {
+    if (relationResult == null || relationResult.getCategoryType() == null) {
+      return null;
+    }
+
+    String message = recordCompareItem ? relationResult.getRecordMessage() : relationResult.getReplayMessage();
+    long createTime = recordCompareItem ? relationResult.getRecordTime() : relationResult.getReplayTime();
+    return new CompareItemImpl(relationResult.getOperationName(), processMessage(message), null,
+            createTime, relationResult.getCategoryType().isEntryPoint());
+  }
+
+  private String processMessage(String message) {
+    if (StringUtils.isBlank(message)) {
+      return message;
+    }
+
+    Target target = JsonUtils.jsonStringToObject(message, Target.class);
+    if (target != null) {
+      message = buildAttributes(target).toString();
+    }
+    return message;
+  }
+
+  private ObjectNode buildAttributes(Target target) {
+    ObjectNode obj = JsonNodeFactory.instance.objectNode();
+    if (target == null) {
+        return obj;
+    }
+    Map<String, Object> attributes = target.getAttributes();
+    if (attributes != null) {
+        for (Entry<String, Object> entry : attributes.entrySet()) {
+            Object value = entry.getValue();
+            if (value instanceof String) {
+                obj.put(entry.getKey(), (String) value);
+            } else {
+                obj.putPOJO(entry.getKey(), value);
+            }
+        }
+    }
+    if (StringUtils.isNotEmpty(target.getBody())) {
+        obj.put("body", target.getBody());
+    }
+    return obj;
+  }
+
+  private String getOperationName(Target target, String operationName) {
+    // The "@" in the operationName of DATABASE indicates that the SQL statement has been parsed and returned directly.
+    String compareOperationName = StringUtils.contains(operationName, "@") ? operationName
+      : target.attributeAsString(MockAttributeNames.DB_NAME);
+    if (StringUtils.isNotBlank(compareOperationName)) {
+      return compareOperationName;
+    }
+    return operationName;
+  }
+}

--- a/arex-schedule-web-api/src/main/java/com/arextest/schedule/comparer/converter/impl/DefaultCompareItemConverterImpl.java
+++ b/arex-schedule-web-api/src/main/java/com/arextest/schedule/comparer/converter/impl/DefaultCompareItemConverterImpl.java
@@ -1,0 +1,54 @@
+package com.arextest.schedule.comparer.converter.impl;
+
+import com.arextest.model.mock.AREXMocker;
+import com.arextest.model.mock.MockCategoryType;
+import com.arextest.model.replay.CompareRelationResult;
+import com.arextest.schedule.comparer.CompareItem;
+import com.arextest.schedule.comparer.converter.CompareItemConverter;
+import com.arextest.schedule.comparer.impl.PrepareCompareItemBuilder.CompareItemImpl;
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author xinyuan_wang.
+ * @create 2024/9/2 16:46
+ */
+@Slf4j
+@Component
+public class DefaultCompareItemConverterImpl implements CompareItemConverter {
+
+  @Override
+  public CompareItem convert(AREXMocker mocker) {
+    if (mocker == null || mocker.getCategoryType() == null) {
+      return null;
+    }
+
+    MockCategoryType categoryType = mocker.getCategoryType();
+    String operationKey = mocker.getOperationName();
+    long createTime = mocker.getCreationTime();
+    String body;
+    String compareKey = mocker.getId();
+    boolean entryPointCategory = false;
+    if (categoryType.isEntryPoint()) {
+      body = Objects.isNull(mocker.getTargetResponse()) ? null
+          : mocker.getTargetResponse().getBody();
+      compareKey = null;
+      entryPointCategory = true;
+    } else {
+      body = Objects.isNull(mocker.getTargetRequest()) ? null
+          : mocker.getTargetRequest().getBody();
+    }
+    return new CompareItemImpl(operationKey, body, compareKey, createTime, entryPointCategory);
+  }
+
+  @Override
+  public CompareItem convert(CompareRelationResult relationResult, boolean recordCompareItem) {
+    if (relationResult == null) {
+      return null;
+    }
+
+    return new CompareItemImpl(relationResult, recordCompareItem);
+  }
+
+}

--- a/arex-schedule-web-api/src/main/java/com/arextest/schedule/comparer/converter/impl/RedisCompareItemConverterImpl.java
+++ b/arex-schedule-web-api/src/main/java/com/arextest/schedule/comparer/converter/impl/RedisCompareItemConverterImpl.java
@@ -1,0 +1,66 @@
+package com.arextest.schedule.comparer.converter.impl;
+
+import com.arextest.model.constants.MockAttributeNames;
+import com.arextest.model.mock.AREXMocker;
+import com.arextest.model.mock.MockCategoryType;
+import com.arextest.model.mock.Mocker.Target;
+import com.arextest.model.replay.CompareRelationResult;
+import com.arextest.schedule.comparer.CompareItem;
+import com.arextest.schedule.comparer.converter.CompareItemConverter;
+import com.arextest.schedule.comparer.impl.PrepareCompareItemBuilder.CompareItemImpl;
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author xinyuan_wang.
+ * @create 2024/9/2 16:46
+ */
+@Slf4j
+@Component
+public class RedisCompareItemConverterImpl implements CompareItemConverter {
+
+  @Override
+  public String getCategoryName() {
+    return MockCategoryType.REDIS.getName();
+  }
+
+  @Override
+  public CompareItem convert(AREXMocker mocker) {
+    if (mocker == null || mocker.getCategoryType() == null) {
+      return null;
+    }
+
+    MockCategoryType categoryType = mocker.getCategoryType();
+    String operationKey = getOperationName(mocker.getTargetRequest(), mocker.getOperationName());
+    String compareMessage = Objects.isNull(mocker.getTargetRequest()) ? null
+        : mocker.getTargetRequest().getBody();
+
+    return new CompareItemImpl(operationKey, compareMessage, mocker.getId(),
+        mocker.getCreationTime(), categoryType.isEntryPoint());
+  }
+  @Override
+  public CompareItem convert(CompareRelationResult relationResult, boolean recordCompareItem) {
+    if (relationResult == null || relationResult.getCategoryType() == null) {
+      return null;
+    }
+
+    String message = recordCompareItem ? relationResult.getRecordMessage() : relationResult.getReplayMessage();
+    long createTime = recordCompareItem ? relationResult.getRecordTime() : relationResult.getReplayTime();
+    return new CompareItemImpl(relationResult.getOperationName(), message, null,
+            createTime, relationResult.getCategoryType().isEntryPoint());
+  }
+
+  private String getOperationName(Target target, String operationName) {
+    if (target == null) {
+      return operationName;
+    }
+
+    String compareOperationName = target.attributeAsString(MockAttributeNames.CLUSTER_NAME);
+    if (StringUtils.isNotBlank(compareOperationName)) {
+      return compareOperationName;
+    }
+    return operationName;
+  }
+}

--- a/arex-schedule-web-api/src/main/java/com/arextest/schedule/comparer/impl/DefaultReplayResultComparer.java
+++ b/arex-schedule-web-api/src/main/java/com/arextest/schedule/comparer/impl/DefaultReplayResultComparer.java
@@ -6,6 +6,7 @@ import com.arextest.diff.model.enumeration.DiffResultCode;
 import com.arextest.diff.sdk.CompareSDK;
 import com.arextest.model.mock.MockCategoryType;
 import com.arextest.schedule.comparer.CategoryComparisonHolder;
+import com.arextest.schedule.comparer.CategoryComparisonHolder.CompareResultItem;
 import com.arextest.schedule.comparer.CompareConfigService;
 import com.arextest.schedule.comparer.CompareItem;
 import com.arextest.schedule.comparer.CompareService;
@@ -162,9 +163,38 @@ public class DefaultReplayResultComparer implements ReplayResultComparer {
   }
 
   /**
-   * compare recording and replay data. 1. record and replay data through compareKey.
+   * compare recording and replay data.
    */
   private List<ReplayCompareResult> compareReplayResult(CategoryComparisonHolder bindHolder,
+      ReplayActionCaseItem caseItem, ComparisonInterfaceConfig operationConfig) {
+    if (Boolean.TRUE.equals(bindHolder.getNeedMatch())) {
+      return matchCompareReplayResults(bindHolder, caseItem, operationConfig);
+    }
+
+    return getReplayCompareResults(bindHolder, caseItem, operationConfig);
+  }
+
+  private List<ReplayCompareResult> getReplayCompareResults(CategoryComparisonHolder bindHolder,
+      ReplayActionCaseItem caseItem, ComparisonInterfaceConfig operationConfig) {
+    CompareResultItem item = bindHolder.getCompareResultItem();
+    if (item == null) {
+      return Collections.emptyList();
+    }
+
+    List<ReplayCompareResult> compareResults = new ArrayList<>();
+    compareResults.add(compareRecordAndResult(operationConfig, caseItem, bindHolder.getCategoryName(),
+        item.getReplayItem(), item.getRecordItem()));
+    return compareResults;
+  }
+
+  /**
+   * record and replay data through compareKey.
+   * @param bindHolder
+   * @param caseItem
+   * @param operationConfig
+   * @return
+   */
+  private List<ReplayCompareResult> matchCompareReplayResults(CategoryComparisonHolder bindHolder,
       ReplayActionCaseItem caseItem, ComparisonInterfaceConfig operationConfig) {
     List<ReplayCompareResult> compareResults = new ArrayList<>();
     List<CompareItem> recordResults = bindHolder.getRecord();

--- a/arex-schedule-web-api/src/main/java/com/arextest/schedule/serialization/ZstdJacksonSerializer.java
+++ b/arex-schedule-web-api/src/main/java/com/arextest/schedule/serialization/ZstdJacksonSerializer.java
@@ -5,6 +5,8 @@ import com.arextest.common.serialization.SerializationProvider;
 import com.arextest.common.serialization.SerializationProviders;
 import com.arextest.common.utils.SerializationUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Base64;
@@ -25,10 +27,24 @@ public final class ZstdJacksonSerializer {
   @Resource
   private ObjectMapper objectMapper;
   private SerializationProvider serializationProvider;
+  public static final byte[] EMPTY_BYTE = new byte[]{};
 
   @PostConstruct
   void initSerializationProvider() {
     this.serializationProvider = SerializationProviders.jacksonProvider(this.objectMapper);
+  }
+
+  public <T> byte[] serialize(T value) {
+    if (value == null) {
+      return EMPTY_BYTE;
+    }
+    try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+      serializeTo(value, out);
+      return out.toByteArray();
+    } catch (IOException e) {
+      LOGGER.error("serialize error:{}", e.getMessage(), e);
+    }
+    return EMPTY_BYTE;
   }
 
   public <T> void serializeTo(T value, OutputStream outputStream) {

--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@
       **/model/**,
       **/mapping/**
     </sonar.exclusions>
-    <arex-storage-config.version>1.2.19</arex-storage-config.version>
+    <arex-storage-config.version>1.3.0</arex-storage-config.version>
     <web-contract.version>0.6.5.2</web-contract.version>
     <arex-common.version>0.2.3</arex-common.version>
     <redisson.version>3.20.1</redisson.version>
@@ -320,5 +320,5 @@
     <url>https://github.com/arextest/arex-replay-schedule</url>
   </scm>
   <url>https://github.com/arextest/arex-replay-schedule</url>
-  <version>1.2.17</version>
+  <version>1.2.18</version>
 </project>


### PR DESCRIPTION
Compatible with replayResult interface logic.

1. needMatch == true, maintain original logic, record and replay data through compareKey.
2. needMatch == false, there is no need to map the matching relationship, just compare directly