### PR TITLE
fix NPE: decode if request body not null

### DIFF
--- a/arex-schedule-web-api/src/main/java/com/arextest/schedule/sender/httprequest/DefaultHttpRequestBuilder.java
+++ b/arex-schedule-web-api/src/main/java/com/arextest/schedule/sender/httprequest/DefaultHttpRequestBuilder.java
@@ -41,7 +41,7 @@ public class DefaultHttpRequestBuilder extends AbstractHttpRequestBuilder {
     Class<?> responseType = String.class;
     String requestMessage = senderParameters.getMessage();
     final HttpEntity<?> httpEntity;
-    if (shouldApplyHttpBody(httpMethod)) {
+    if (shouldApplyHttpBody(httpMethod) && requestMessage != null) {
       Object decodeMessage = DecodeUtils.decode(requestMessage);
       if (byte[].class == decodeMessage.getClass()) {
         responseType = byte[].class;


### PR DESCRIPTION
<img width="783" alt="image" src="https://github.com/user-attachments/assets/5f86ff0e-2e0a-4574-81ec-35dd02b4bf47">

回放时 requestMessage 为空，导致回放异常，这里判断不为空再 decode 